### PR TITLE
Add `email.templates.confirm.confirmation_url`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "toml",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2615,6 +2616,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ toml = { version = "0.8.8" }
 tokio = { version = "1.34.0", features = ["macros", "rt"] }
 prefixed-api-key = { version = "0.1.0", features = ["sha2"]}
 prettytable-rs = { version = "0.10.0"}
-urlencoding = "2.1.3"
+urlencoding = { version = "2.1.3" }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ toml = { version = "0.8.8" }
 tokio = { version = "1.34.0", features = ["macros", "rt"] }
 prefixed-api-key = { version = "0.1.0", features = ["sha2"]}
 prettytable-rs = { version = "0.10.0"}
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -1,3 +1,4 @@
+use crate::email::templating::render_confirmation_template;
 use crate::error::AybError;
 use crate::http::structs::AybConfigEmail;
 use lettre::{
@@ -6,6 +7,8 @@ use lettre::{
     transport::smtp::client::{Tls, TlsParameters},
     AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor,
 };
+
+mod templating;
 
 pub async fn send_registration_email(
     to: &str,
@@ -16,7 +19,7 @@ pub async fn send_registration_email(
     send_email(
         to,
         "Your login credentials",
-        format!("To log in, type\n\tayb client confirm {token}"),
+        render_confirmation_template(config, token),
         config,
         e2e_testing_on,
     )

--- a/src/email/templating.rs
+++ b/src/email/templating.rs
@@ -1,0 +1,19 @@
+use crate::http::structs::AybConfigEmail;
+
+const CLI_CONFIRM_TMPL: &str = "To complete your registration, type\n\tayb client confirm {token}";
+const WEB_CONFIRM_TMPL: &str = "To complete your registration, visit\n\t <{url}>";
+
+pub fn render_confirmation_template(config: &AybConfigEmail, token: &str) -> String {
+    if let Some(tmpl_conf) = &config.templates {
+        if let Some(confirm_conf) = &tmpl_conf.confirm {
+            return WEB_CONFIRM_TMPL.replace(
+                "{url}",
+                &confirm_conf
+                    .confirmation_url
+                    .replace("{token}", &urlencoding::encode(token)),
+            );
+        }
+    }
+
+    CLI_CONFIRM_TMPL.replace("{token}", token)
+}

--- a/src/email/templating.rs
+++ b/src/email/templating.rs
@@ -1,7 +1,7 @@
 use crate::http::structs::AybConfigEmail;
 
 const CLI_CONFIRM_TMPL: &str = "To complete your registration, type\n\tayb client confirm {token}";
-const WEB_CONFIRM_TMPL: &str = "To complete your registration, visit\n\t <{url}>";
+const WEB_CONFIRM_TMPL: &str = "To complete your registration, visit\n\t {url}";
 
 pub fn render_confirmation_template(config: &AybConfigEmail, token: &str) -> String {
     if let Some(tmpl_conf) = &config.templates {

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -28,6 +28,7 @@ pub fn default_server_config() -> AybConfig {
             smtp_port: 465,
             smtp_username: "login@example.org".to_string(),
             smtp_password: "the_password".to_string(),
+            templates: None,
         },
     }
 }

--- a/src/http/structs.rs
+++ b/src/http/structs.rs
@@ -11,6 +11,16 @@ pub struct AybConfigAuthentication {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+pub struct AybConfigEmailTemplatesConfirm {
+    pub confirmation_url: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AybConfigEmailTemplates {
+    pub confirm: Option<AybConfigEmailTemplatesConfirm>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AybConfigEmail {
     pub from: String,
     pub reply_to: String,
@@ -18,6 +28,7 @@ pub struct AybConfigEmail {
     pub smtp_port: u16,
     pub smtp_username: String,
     pub smtp_password: String,
+    pub templates: Option<AybConfigEmailTemplates>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This allows server operators to send a URL instead of an `ayb client` command as discussed in #216.

This is the _initial_ templating system. In the future a fully customizable templating system will be added.

Note for implementors: the token is [URI encoded](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) when the URL is generated. Example `email.templates.confirm.confirmation_url`: `https://ayb.sofiaritz.com/auth/confirm?token={token}`