### PR TITLE
Limit the number of attached databases to zero and enable defensive mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ fernet = { version = "0.2.1" }
 lettre = { version = "0.10.4", features = ["tokio1-native-tls"] }
 quoted_printable = { version = "0.5.0" }
 reqwest = { version = "0.11.22", features = ["json"] }
-rusqlite = { version = "0.27.0", features = ["bundled"] }
+rusqlite = { version = "0.27.0", features = ["bundled", "limits"] }
 regex = { version = "1.10.2"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.108" }

--- a/src/hosted_db/sqlite.rs
+++ b/src/hosted_db/sqlite.rs
@@ -1,11 +1,21 @@
 use crate::error::AybError;
 use crate::hosted_db::QueryResult;
 use rusqlite;
+use rusqlite::config::DbConfig;
+use rusqlite::limits::Limit;
 use rusqlite::types::ValueRef;
 use std::path::PathBuf;
 
 pub fn run_sqlite_query(path: &PathBuf, query: &str) -> Result<QueryResult, AybError> {
     let conn = rusqlite::Connection::open(path)?;
+
+    // Disable the usage of ATTACH
+    // https://www.sqlite.org/lang_attach.html
+    conn.set_limit(Limit::SQLITE_LIMIT_ATTACHED, 0);
+    // Prevent queries from deliberately corrupting the database
+    // https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
+    conn.db_config(DbConfig::SQLITE_DBCONFIG_DEFENSIVE)?;
+
     let mut prepared = conn.prepare(query)?;
     let num_columns = prepared.column_count();
     let mut fields: Vec<String> = Vec::new();


### PR DESCRIPTION
Related to #41.
This PR limits the number maximum attached databases to zero (none) and enables defensive mode to prevent deliberate corruption of the database.

Refs:
https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
https://www.sqlite.org/lang_attach.html
https://www.sqlite.org/c3ref/c_limit_attached.html#sqlitelimitattached
https://www.sqlite.org/c3ref/limit.html