### PR TITLE
Improve database interfaces

### DIFF
--- a/src/ayb_db/db_interfaces.rs
+++ b/src/ayb_db/db_interfaces.rs
@@ -37,7 +37,10 @@ pub trait AybDb: DynClone + Send + Sync {
         entity_slug: &str,
         database_slug: &str,
     ) -> Result<InstantiatedDatabase, AybError>;
-    async fn get_entity_by_slug(&self, entity_slug: &str) -> Result<Option<InstantiatedEntity>, AybError>;
+    async fn get_entity_by_slug(
+        &self,
+        entity_slug: &str,
+    ) -> Result<Option<InstantiatedEntity>, AybError>;
     async fn get_entity_by_id(&self, entity_id: i32) -> Result<InstantiatedEntity, AybError>;
     async fn list_authentication_methods(
         &self,

--- a/src/http/endpoints/create_database.rs
+++ b/src/http/endpoints/create_database.rs
@@ -24,7 +24,7 @@ async fn create_database(
     if entity.is_none() {
         return Err(AybError {
             message: format!("Entity not found: {:?}", entity_slug),
-        })
+        });
     }
 
     let entity = entity.unwrap();

--- a/src/http/endpoints/create_database.rs
+++ b/src/http/endpoints/create_database.rs
@@ -20,6 +20,14 @@ async fn create_database(
     let entity_slug = &path.entity;
     let entity = ayb_db.get_entity_by_slug(entity_slug).await?;
     let db_type = get_header(&req, "db-type")?;
+
+    if entity.is_none() {
+        return Err(AybError {
+            message: format!("Entity not found: {:?}", entity_slug),
+        })
+    }
+
+    let entity = entity.unwrap();
     let database = Database {
         entity_id: entity.id,
         slug: path.database.clone(),

--- a/src/http/endpoints/entity_details.rs
+++ b/src/http/endpoints/entity_details.rs
@@ -16,6 +16,13 @@ pub async fn entity_details(
     let entity_slug = &path.entity;
     let desired_entity = ayb_db.get_entity_by_slug(entity_slug).await?;
 
+    if desired_entity.is_none() {
+        return Err(AybError {
+            message: format!("Entity not found {:?}", entity_slug),
+        })
+    }
+
+    let desired_entity = desired_entity.unwrap();
     let databases = ayb_db
         .list_databases_by_entity(&desired_entity)
         .await?

--- a/src/http/endpoints/entity_details.rs
+++ b/src/http/endpoints/entity_details.rs
@@ -19,7 +19,7 @@ pub async fn entity_details(
     if desired_entity.is_none() {
         return Err(AybError {
             message: format!("Entity not found {:?}", entity_slug),
-        })
+        });
     }
 
     let desired_entity = desired_entity.unwrap();

--- a/src/http/endpoints/log_in.rs
+++ b/src/http/endpoints/log_in.rs
@@ -17,7 +17,7 @@ async fn log_in(
     let entity = get_lowercased_header(&req, "entity")?;
     let desired_entity = ayb_db.get_entity_by_slug(&entity).await;
 
-    if let Ok(instantiated_entity) = desired_entity {
+    if let Ok(Some(instantiated_entity)) = desired_entity {
         let auth_methods = ayb_db
             .list_authentication_methods(&instantiated_entity)
             .await?;

--- a/src/http/endpoints/register.rs
+++ b/src/http/endpoints/register.rs
@@ -21,7 +21,7 @@ async fn register(
     // Ensure that there are no authentication methods aside from
     // perhaps the currently requested one.
     let mut already_verified = false;
-    if let Ok(instantiated_entity) = desired_entity {
+    if let Ok(Some(instantiated_entity)) = desired_entity {
         let auth_methods = ayb_db
             .list_authentication_methods(&instantiated_entity)
             .await?;

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -41,10 +41,17 @@ async fn entity_validator(
                 Ok(api_token) => {
                     let entity = ayb_db.get_entity_by_id(api_token.entity_id).await;
                     match entity {
-                        Ok(entity) => {
+                        Ok(Some(entity)) => {
                             req.extensions_mut().insert(entity);
                             Ok(req)
                         }
+                        Ok(None) => Err((
+                            AybError {
+                                message: format!("Entity not found: {:?}", api_token.entity_id),
+                            }
+                            .into(),
+                            req,
+                        )),
                         Err(e) => Err((e.into(), req)),
                     }
                 }

--- a/src/http/tokens.rs
+++ b/src/http/tokens.rs
@@ -66,7 +66,14 @@ pub async fn retrieve_and_validate_api_token(
 ) -> Result<APIToken, AybError> {
     let controller = api_key_controller()?;
     let pak = PrefixedApiKey::from_string(token)?;
-    let api_token = (ayb_db.get_api_token(pak.short_token())).await?;
+    let api_token = ayb_db.get_api_token(pak.short_token()).await?;
+    if api_token.is_none() {
+        return Err(AybError {
+            message: format!("API Token not found {:?}", pak.short_token()),
+        });
+    }
+
+    let api_token = api_token.unwrap();
     if !controller.check_hash(&pak, &api_token.hash) {
         return Err(AybError {
             message: "Invalid API token".to_string(),


### PR DESCRIPTION
This PR updates some functions from `db_interfaces` to return an Option instead of an error when `query_as` returns a `RowNotFound` error.

Related to #237