### PR TITLE
Replace `AybError` with an enum

### DIFF
--- a/src/ayb_db/db_interfaces.rs
+++ b/src/ayb_db/db_interfaces.rs
@@ -125,7 +125,7 @@ RETURNING entity_id, short_token, hash, status
                     sqlx::Error::Database(db_error)
                         if self.is_duplicate_constraint_error(&*db_error) =>
                     {
-                        Err(AybError {
+                        Err(AybError::Other {
                             message: format!("Database already exists"),
                         })
                     }
@@ -154,9 +154,7 @@ WHERE short_token = $1
                 .fetch_one(&self.pool)
                 .await
                 .or_else(|err| match err {
-                    sqlx::Error::RowNotFound => Err(AybError {
-                        message: format!("API Token not found: {:?}", short_token),
-                    }),
+                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
                     _ => Err(AybError::from(err)),
                 })?;
 
@@ -208,9 +206,7 @@ WHERE slug = $1
                 .fetch_one(&self.pool)
                 .await
                 .or_else(|err| match err {
-                    sqlx::Error::RowNotFound => Err(AybError {
-                        message: format!("Entity not found: {:?}", entity_slug),
-                    }),
+                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
                     _ => Err(AybError::from(err)),
                 })?;
 
@@ -235,9 +231,7 @@ WHERE id = $1
                 .fetch_one(&self.pool)
                 .await
                 .or_else(|err| match err {
-                    sqlx::Error::RowNotFound => Err(AybError {
-                        message: format!("Entity not found: {:?}", entity_id),
-                    }),
+                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
                     _ => Err(AybError::from(err)),
                 })?;
 
@@ -378,7 +372,7 @@ pub async fn connect_to_ayb_db(url: String) -> Result<Box<dyn AybDb>, AybError> 
     } else if url.starts_with("postgres") {
         Ok(Box::new(PostgresAybDb::connect(url).await))
     } else {
-        Err(AybError {
+        Err(AybError::Other {
             message: format!(
                 "Database type for {} is not supported (currently only SQLite and PostgreSQL)",
                 url

--- a/src/ayb_db/db_interfaces.rs
+++ b/src/ayb_db/db_interfaces.rs
@@ -152,11 +152,7 @@ WHERE short_token = $1
                 )
                 .bind(short_token)
                 .fetch_one(&self.pool)
-                .await
-                .or_else(|err| match err {
-                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
-                    _ => Err(AybError::from(err)),
-                })?;
+                .await?;
 
                 Ok(api_token)
             }
@@ -204,11 +200,7 @@ WHERE slug = $1
                 )
                 .bind(entity_slug)
                 .fetch_one(&self.pool)
-                .await
-                .or_else(|err| match err {
-                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
-                    _ => Err(AybError::from(err)),
-                })?;
+                .await?;
 
                 Ok(entity)
             }
@@ -229,11 +221,7 @@ WHERE id = $1
                 )
                 .bind(entity_id)
                 .fetch_one(&self.pool)
-                .await
-                .or_else(|err| match err {
-                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
-                    _ => Err(AybError::from(err)),
-                })?;
+                .await?;
 
                 Ok(entity)
             }

--- a/src/ayb_db/db_interfaces.rs
+++ b/src/ayb_db/db_interfaces.rs
@@ -154,7 +154,10 @@ WHERE short_token = $1
                 .fetch_one(&self.pool)
                 .await
                 .or_else(|err| match err {
-                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
+                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound {
+                        id: short_token.into(),
+                        record_type: "api_token".into(),
+                    }),
                     _ => Err(AybError::from(err)),
                 })?;
 
@@ -206,7 +209,10 @@ WHERE slug = $1
                 .fetch_one(&self.pool)
                 .await
                 .or_else(|err| match err {
-                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
+                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound {
+                        id: entity_slug.into(),
+                        record_type: "entity".into(),
+                    }),
                     _ => Err(AybError::from(err)),
                 })?;
 
@@ -231,7 +237,10 @@ WHERE id = $1
                 .fetch_one(&self.pool)
                 .await
                 .or_else(|err| match err {
-                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
+                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound {
+                        id: entity_id.to_string(),
+                        record_type: "entity".into(),
+                    }),
                     _ => Err(AybError::from(err)),
                 })?;
 

--- a/src/ayb_db/db_interfaces.rs
+++ b/src/ayb_db/db_interfaces.rs
@@ -152,7 +152,11 @@ WHERE short_token = $1
                 )
                 .bind(short_token)
                 .fetch_one(&self.pool)
-                .await?;
+                .await
+                .or_else(|err| match err {
+                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
+                    _ => Err(AybError::from(err)),
+                })?;
 
                 Ok(api_token)
             }
@@ -200,7 +204,11 @@ WHERE slug = $1
                 )
                 .bind(entity_slug)
                 .fetch_one(&self.pool)
-                .await?;
+                .await
+                .or_else(|err| match err {
+                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
+                    _ => Err(AybError::from(err)),
+                })?;
 
                 Ok(entity)
             }
@@ -221,7 +229,11 @@ WHERE id = $1
                 )
                 .bind(entity_id)
                 .fetch_one(&self.pool)
-                .await?;
+                .await
+                .or_else(|err| match err {
+                    sqlx::Error::RowNotFound => Err(AybError::RecordNotFound),
+                    _ => Err(AybError::from(err)),
+                })?;
 
                 Ok(entity)
             }

--- a/src/ayb_db/models.rs
+++ b/src/ayb_db/models.rs
@@ -13,7 +13,7 @@ macro_rules! try_from_i16 {
             fn try_from(value: i16) -> Result<Self, Self::Error> {
                 match value {
                     $($left => Ok($right),)*
-                    _ => Err(Self::Error {
+                    _ => Err(Self::Error::Other {
                         message: format!("Unknown value: {}", value),
                     }),
                 }
@@ -30,7 +30,7 @@ macro_rules! from_str {
             fn from_str(value: &str) -> Result<Self, Self::Err> {
                 match value {
                     $($left => Ok($right),)*
-                    _ => Err(Self::Err {
+                    _ => Err(Self::Err::Other {
                         message: format!("Unknown value: {}", value),
                     }),
                 }

--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -70,7 +70,7 @@ async fn send_email(
     }
 
     if let Err(e) = mailer.send(email).await {
-        return Err(AybError {
+        return Err(AybError::Other {
             message: format!("Could not send email: {e:?}"),
         });
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use actix_web;
-use derive_more::{Display, Error};
+use derive_more::Error;
 use fernet;
 use lettre;
 use prefixed_api_key;
@@ -9,14 +9,21 @@ use rusqlite;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use sqlx;
+use std::fmt::{Display, Formatter};
 use std::string;
 use toml;
 
-#[derive(Debug, Deserialize, Display, Error, Serialize)]
+#[derive(Debug, Deserialize, Error, Serialize)]
 #[serde(tag = "type", content = "value")]
 pub enum AybError {
-    RecordNotFound,
+    RecordNotFound { id: String, record_type: String },
     Other { message: String },
+}
+
+impl Display for AybError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 impl actix_web::error::ResponseError for AybError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,8 +115,11 @@ impl From<std::io::Error> for AybError {
 
 impl From<sqlx::Error> for AybError {
     fn from(cause: sqlx::Error) -> Self {
-        AybError::Other {
-            message: format!("{:?}", cause),
+        match cause {
+            sqlx::Error::RowNotFound => Self::RecordNotFound,
+            _ => Self::Other {
+                message: format!("{:?}", cause),
+            }
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,11 +115,8 @@ impl From<std::io::Error> for AybError {
 
 impl From<sqlx::Error> for AybError {
     fn from(cause: sqlx::Error) -> Self {
-        match cause {
-            sqlx::Error::RowNotFound => Self::RecordNotFound,
-            _ => Self::Other {
-                message: format!("{:?}", cause),
-            }
+        AybError::Other {
+            message: format!("{:?}", cause),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,8 +13,10 @@ use std::string;
 use toml;
 
 #[derive(Debug, Deserialize, Display, Error, Serialize)]
-pub struct AybError {
-    pub message: String,
+#[serde(tag = "type", content = "value")]
+pub enum AybError {
+    RecordNotFound,
+    Other { message: String },
 }
 
 impl actix_web::error::ResponseError for AybError {
@@ -25,7 +27,7 @@ impl actix_web::error::ResponseError for AybError {
 
 impl From<fernet::DecryptionError> for AybError {
     fn from(_cause: fernet::DecryptionError) -> Self {
-        AybError {
+        AybError::Other {
             message: "Invalid or expired token".to_owned(),
         }
     }
@@ -33,7 +35,7 @@ impl From<fernet::DecryptionError> for AybError {
 
 impl From<lettre::address::AddressError> for AybError {
     fn from(cause: lettre::address::AddressError) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("Invalid email address: {}", cause),
         }
     }
@@ -41,7 +43,7 @@ impl From<lettre::address::AddressError> for AybError {
 
 impl From<prefixed_api_key::BuilderError> for AybError {
     fn from(cause: prefixed_api_key::BuilderError) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("Error in prefixed API key builder: {}", cause),
         }
     }
@@ -49,7 +51,7 @@ impl From<prefixed_api_key::BuilderError> for AybError {
 
 impl From<prefixed_api_key::PrefixedApiKeyError> for AybError {
     fn from(cause: prefixed_api_key::PrefixedApiKeyError) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("Error parsing API token: {}", cause),
         }
     }
@@ -57,7 +59,7 @@ impl From<prefixed_api_key::PrefixedApiKeyError> for AybError {
 
 impl From<quoted_printable::QuotedPrintableError> for AybError {
     fn from(cause: quoted_printable::QuotedPrintableError) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("{:?}", cause),
         }
     }
@@ -65,7 +67,7 @@ impl From<quoted_printable::QuotedPrintableError> for AybError {
 
 impl From<rusqlite::Error> for AybError {
     fn from(cause: rusqlite::Error) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("{:?}", cause),
         }
     }
@@ -73,7 +75,7 @@ impl From<rusqlite::Error> for AybError {
 
 impl From<rusqlite::types::FromSqlError> for AybError {
     fn from(cause: rusqlite::types::FromSqlError) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("{:?}", cause),
         }
     }
@@ -81,7 +83,7 @@ impl From<rusqlite::types::FromSqlError> for AybError {
 
 impl From<string::FromUtf8Error> for AybError {
     fn from(cause: string::FromUtf8Error) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("{:?}", cause),
         }
     }
@@ -89,7 +91,7 @@ impl From<string::FromUtf8Error> for AybError {
 
 impl From<serde_json::Error> for AybError {
     fn from(cause: serde_json::Error) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("{:?}", cause),
         }
     }
@@ -97,7 +99,7 @@ impl From<serde_json::Error> for AybError {
 
 impl From<std::str::Utf8Error> for AybError {
     fn from(cause: std::str::Utf8Error) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("{:?}", cause),
         }
     }
@@ -105,7 +107,7 @@ impl From<std::str::Utf8Error> for AybError {
 
 impl From<std::io::Error> for AybError {
     fn from(cause: std::io::Error) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("IO error: {:?}", cause),
         }
     }
@@ -113,7 +115,7 @@ impl From<std::io::Error> for AybError {
 
 impl From<sqlx::Error> for AybError {
     fn from(cause: sqlx::Error) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("{:?}", cause),
         }
     }
@@ -121,7 +123,7 @@ impl From<sqlx::Error> for AybError {
 
 impl From<reqwest::Error> for AybError {
     fn from(cause: reqwest::Error) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("{:?}", cause),
         }
     }
@@ -129,7 +131,7 @@ impl From<reqwest::Error> for AybError {
 
 impl From<toml::de::Error> for AybError {
     fn from(cause: toml::de::Error) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("Unable to deserialize toml string: {:?}", cause),
         }
     }
@@ -137,7 +139,7 @@ impl From<toml::de::Error> for AybError {
 
 impl From<toml::ser::Error> for AybError {
     fn from(cause: toml::ser::Error) -> Self {
-        AybError {
+        AybError::Other {
             message: format!("Unable to serialize toml string: {:?}", cause),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,10 @@ pub enum AybError {
 
 impl Display for AybError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            AybError::Other { message } => write!(f, "{}", message),
+            _ => write!(f, "{:?}", self),
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -119,7 +119,7 @@ impl From<sqlx::Error> for AybError {
             sqlx::Error::RowNotFound => Self::RecordNotFound,
             _ => Self::Other {
                 message: format!("{:?}", cause),
-            }
+            },
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ use std::string;
 use toml;
 
 #[derive(Debug, Deserialize, Error, Serialize)]
-#[serde(tag = "type", content = "value")]
+#[serde(tag = "type")]
 pub enum AybError {
     RecordNotFound { id: String, record_type: String },
     Other { message: String },

--- a/src/error.rs
+++ b/src/error.rs
@@ -119,7 +119,7 @@ impl From<sqlx::Error> for AybError {
             sqlx::Error::RowNotFound => Self::RecordNotFound,
             _ => Self::Other {
                 message: format!("{:?}", cause),
-            },
+            }
         }
     }
 }

--- a/src/hosted_db.rs
+++ b/src/hosted_db.rs
@@ -56,7 +56,7 @@ impl QueryResult {
 pub fn run_query(path: &PathBuf, query: &str, db_type: &DBType) -> Result<QueryResult, AybError> {
     match db_type {
         DBType::Sqlite => Ok(run_sqlite_query(path, query)?),
-        _ => Err(AybError {
+        _ => Err(AybError::Other {
             message: "Unsupported DB type".to_string(),
         }),
     }

--- a/src/hosted_db/paths.rs
+++ b/src/hosted_db/paths.rs
@@ -9,7 +9,7 @@ pub fn database_path(
 ) -> Result<PathBuf, AybError> {
     let mut path: PathBuf = [data_path, entity_slug].iter().collect();
     if let Err(e) = fs::create_dir_all(&path) {
-        return Err(AybError {
+        return Err(AybError::Other {
             message: format!("Unable to create entity path for {}: {}", entity_slug, e),
         });
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -23,7 +23,7 @@ impl AybClient {
             );
             Ok(())
         } else {
-            Err(AybError {
+            Err(AybError::Other {
                 message: "Calling endpoint that requires client API token, but none provided"
                     .to_string(),
             })
@@ -37,7 +37,7 @@ impl AybClient {
     ) -> Result<T, AybError> {
         let status = response.status();
         if status == expected_status {
-            response.json::<T>().await.map_err(|err| AybError {
+            response.json::<T>().await.map_err(|err| AybError::Other {
                 message: format!("Unable to parse successful response: {}", err),
             })
         } else {
@@ -45,7 +45,7 @@ impl AybClient {
                 .json::<AybError>()
                 .await
                 .map(|v| Err(v))
-                .map_err(|error| AybError {
+                .map_err(|error| AybError::Other {
                     message: format!(
                         "Unable to parse error response: {:#?}, response code: {}",
                         error, status

--- a/src/http/endpoints/confirm.rs
+++ b/src/http/endpoints/confirm.rs
@@ -47,7 +47,7 @@ async fn confirm(
         // if it was previously created, or if there is no other
         // verification method already verified.
         if already_verified {
-            return Err(AybError {
+            return Err(AybError::Other {
                 message: format!("{} has already been registered", created_entity.slug),
             });
         }

--- a/src/http/endpoints/create_database.rs
+++ b/src/http/endpoints/create_database.rs
@@ -30,7 +30,7 @@ async fn create_database(
         let created_database = ayb_db.create_database(&database).await?;
         Ok(HttpResponse::Created().json(APIDatabase::from_persisted(&entity, &created_database)))
     } else {
-        Err(AybError {
+        Err(AybError::Other {
             message: format!(
                 "Authenticated entity {} can not create a database for entity {}",
                 authenticated_entity.slug, entity_slug

--- a/src/http/endpoints/log_in.rs
+++ b/src/http/endpoints/log_in.rs
@@ -48,7 +48,7 @@ async fn log_in(
         }
     }
 
-    Err(AybError {
+    Err(AybError::Other {
         message: format!("No account or email authentication method for {}", entity),
     })
 }

--- a/src/http/endpoints/query.rs
+++ b/src/http/endpoints/query.rs
@@ -29,7 +29,7 @@ async fn query(
         let result = run_query(&db_path, &query, &db_type)?;
         Ok(web::Json(result))
     } else {
-        Err(AybError {
+        Err(AybError::Other {
             message: format!(
                 "Authenticated entity {} can not query database {}/{}",
                 authenticated_entity.slug, entity_slug, database_slug

--- a/src/http/endpoints/register.rs
+++ b/src/http/endpoints/register.rs
@@ -37,7 +37,7 @@ async fn register(
     }
 
     if already_verified {
-        return Err(AybError {
+        return Err(AybError::Other {
             message: format!("{} has already been registered", entity),
         });
     }

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -52,7 +52,7 @@ async fn entity_validator(
             }
         }
         None => Err((
-            AybError {
+            AybError::Other {
                 message: "Misconfigured server: no database".to_string(),
             }
             .into(),

--- a/src/http/tokens.rs
+++ b/src/http/tokens.rs
@@ -14,7 +14,7 @@ const API_TOKEN_PREFIX: &str = "ayb";
 fn get_fernet_generator(auth_config: &AybConfigAuthentication) -> Result<Fernet, AybError> {
     match Fernet::new(&auth_config.fernet_key) {
         Some(token_generator) => Ok(token_generator),
-        None => Err(AybError {
+        None => Err(AybError::Other {
             message: "Missing or invalid Fernet key".to_string(),
         }),
     }
@@ -68,7 +68,7 @@ pub async fn retrieve_and_validate_api_token(
     let pak = PrefixedApiKey::from_string(token)?;
     let api_token = (ayb_db.get_api_token(pak.short_token())).await?;
     if !controller.check_hash(&pak, &api_token.hash) {
-        return Err(AybError {
+        return Err(AybError::Other {
             message: "Invalid API token".to_string(),
         });
     }

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -6,11 +6,11 @@ pub fn get_header(req: &HttpRequest, header_name: &str) -> Result<String, AybErr
     match req.headers().get(header_name) {
         Some(header) => match header.to_str() {
             Ok(header_value) => Ok(header_value.to_owned()),
-            Err(err) => Err(AybError {
+            Err(err) => Err(AybError::Other {
                 message: err.to_string(),
             }),
         },
-        None => Err(AybError {
+        None => Err(AybError::Other {
             message: format!("Missing required `{}` header", header_name),
         }),
     }
@@ -25,7 +25,7 @@ pub fn unwrap_authenticated_entity(
 ) -> Result<InstantiatedEntity, AybError> {
     match entity {
         Some(instantiated_entity) => Ok(instantiated_entity.clone().into_inner()),
-        None => Err(AybError {
+        None => Err(AybError::Other {
             message: "Endpoint requires an entity, but one was not provided".to_string(),
         }),
     }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -24,7 +24,7 @@ pub fn extract_api_key(output: &Output) -> Result<String, AybError> {
         let captures = re.captures(output_str).unwrap();
         Ok(captures.get(1).map_or("", |m| m.as_str()).to_string())
     } else {
-        Err(AybError {
+        Err(AybError::Other {
             message: "No API key".to_string(),
         })
     }
@@ -41,7 +41,7 @@ pub fn extract_token(email: &EmailEntry) -> Result<String, AybError> {
             )?)?);
         }
     }
-    Err(AybError {
+    Err(AybError::Other {
         message: "No token found in email".to_string(),
     })
 }


### PR DESCRIPTION
In this initial iteration only two variants are defined: `RecordNotFound` and `Other`, the second one contains a message.

The enum is tagged under "type". This means that a JSON response would look like this:
```json
{
    "type": "Other",
    "message": "..."
}
```

Related to #103 and #238.