### PR TITLE
Move databases into their own directory, introduce snapshot path (changes storage format, requires migration)

### DIFF
--- a/src/hosted_db/paths.rs
+++ b/src/hosted_db/paths.rs
@@ -1,6 +1,14 @@
 use crate::error::AybError;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+const DATABASES: &str = "databases";
+const SNAPSHOTS: &str = "snapshots";
+
+pub fn database_parent_path(data_path: &str) -> Result<PathBuf, AybError> {
+    let path: PathBuf = [data_path, DATABASES].iter().collect();
+    Ok(fs::canonicalize(path)?)
+}
 
 pub fn database_path(
     entity_slug: &str,
@@ -8,7 +16,12 @@ pub fn database_path(
     data_path: &str,
     create_database: bool,
 ) -> Result<PathBuf, AybError> {
-    let mut path: PathBuf = [data_path, entity_slug].iter().collect();
+    // We place each database in its own directory because databases
+    // might span multiple files (e.g, the SQLite database file as
+    // well as a journal/write-ahead log.
+    let mut path: PathBuf = [data_path, DATABASES, entity_slug, database_slug]
+        .iter()
+        .collect();
     if create_database {
         if let Err(e) = fs::create_dir_all(&path) {
             return Err(AybError::Other {
@@ -23,5 +36,54 @@ pub fn database_path(
         fs::File::create(path.clone())?;
     }
 
-    Ok(path)
+    Ok(fs::canonicalize(path)?)
+}
+
+pub fn database_snapshot_path(
+    entity_slug: &str,
+    database_slug: &str,
+    snapshot_slug: &str,
+    data_path: &str,
+) -> Result<PathBuf, AybError> {
+    let path: PathBuf = [
+        data_path,
+        SNAPSHOTS,
+        entity_slug,
+        database_slug,
+        snapshot_slug,
+    ]
+    .iter()
+    .collect();
+    if let Err(e) = fs::create_dir_all(&path) {
+        return Err(AybError::Other {
+            message: format!(
+                "Unable to create snapshot path for {}/{}: {}",
+                entity_slug, database_slug, e
+            ),
+        });
+    }
+
+    Ok(fs::canonicalize(path)?)
+}
+
+pub fn pathbuf_to_file_name(path: &Path) -> Result<String, AybError> {
+    Ok(path
+        .file_name()
+        .ok_or(AybError::Other {
+            message: format!("Could not parse file name from path: {}", path.display()),
+        })?
+        .to_str()
+        .ok_or(AybError::Other {
+            message: format!("Could not convert path to string: {}", path.display()),
+        })?
+        .to_string())
+}
+
+pub fn pathbuf_to_parent(path: &Path) -> Result<PathBuf, AybError> {
+    Ok(path
+        .parent()
+        .ok_or(AybError::Other {
+            message: format!("Unable to find parent directory of {}", path.display()),
+        })?
+        .to_owned())
 }

--- a/src/hosted_db/paths.rs
+++ b/src/hosted_db/paths.rs
@@ -18,7 +18,7 @@ pub fn database_path(
 ) -> Result<PathBuf, AybError> {
     // We place each database in its own directory because databases
     // might span multiple files (e.g, the SQLite database file as
-    // well as a journal/write-ahead log.
+    // well as a journal/write-ahead log).
     let mut path: PathBuf = [data_path, DATABASES, entity_slug, database_slug]
         .iter()
         .collect();


### PR DESCRIPTION
Related to #14 
* Databases used to be in ayb_data/entity/databasename.sqlite
* Databases are now in ayb_data/databases/entity/databasename.sqlite/[databasename.sqlite and any other journal/write-ahead log files]
* Snapshots will live in ayb_data/snapshots/entity/databasename.sqlite/snapshotname