### PR TITLE
Unsafe mode for SQLite querying

### DIFF
--- a/src/bin/ayb_isolated_runner.rs
+++ b/src/bin/ayb_isolated_runner.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), serde_json::Error> {
     let args: Vec<String> = env::args().collect();
     let db_file = &args[1];
     let query = (args[2..]).to_vec();
-    let result = query_sqlite(&PathBuf::from(db_file), &query.join(" "));
+    let result = query_sqlite(&PathBuf::from(db_file), &query.join(" "), false);
     match result {
         Ok(result) => println!("{}", serde_json::to_string(&result)?),
         Err(error) => eprintln!("{}", serde_json::to_string(&error)?),

--- a/src/hosted_db/sqlite.rs
+++ b/src/hosted_db/sqlite.rs
@@ -7,15 +7,24 @@ use rusqlite::types::ValueRef;
 use serde_json;
 use std::path::{Path, PathBuf};
 
-pub fn query_sqlite(path: &PathBuf, query: &str) -> Result<QueryResult, AybError> {
+/// `allow_unsafe` disables features that prevent abuse but also
+/// prevent backups/snapshots. The only known use case in the codebase
+/// is for snapshots.
+pub fn query_sqlite(
+    path: &PathBuf,
+    query: &str,
+    allow_unsafe: bool,
+) -> Result<QueryResult, AybError> {
     let conn = rusqlite::Connection::open(path)?;
 
-    // Disable the usage of ATTACH
-    // https://www.sqlite.org/lang_attach.html
-    conn.set_limit(Limit::SQLITE_LIMIT_ATTACHED, 0);
-    // Prevent queries from deliberately corrupting the database
-    // https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
-    conn.db_config(DbConfig::SQLITE_DBCONFIG_DEFENSIVE)?;
+    if !allow_unsafe {
+        // Disable the usage of ATTACH
+        // https://www.sqlite.org/lang_attach.html
+        conn.set_limit(Limit::SQLITE_LIMIT_ATTACHED, 0);
+        // Prevent queries from deliberately corrupting the database
+        // https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
+        conn.db_config(DbConfig::SQLITE_DBCONFIG_DEFENSIVE)?;
+    }
 
     let mut prepared = conn.prepare(query)?;
     let num_columns = prepared.column_count();
@@ -79,5 +88,5 @@ pub async fn potentially_isolated_sqlite_query(
     }
 
     // No isolation configuration, so run the query without a sandbox.
-    query_sqlite(path, query)
+    query_sqlite(path, query, false)
 }


### PR DESCRIPTION
Related to #14 

* The regular query path for querying SQLite still uses all of our isolation flags (e.g., you can't `ATTACH` to other databases)
* But for things like backups, one database (the source) has to attach to another database (the backup destination), so we expose an `allow_unsafe` flag to facilitate this