### PR TITLE
Bump prefixed-api-key to 0.2.0 and fix a related Clippy error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,9 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "prefixed-api-key"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f117b34dde5c1df3a3da7735f7a7eed170bbc87dc8ac5fbe9a763410e96546e"
+checksum = "83a1392c6490debe7283eeb8fd424c41a5f9a2751ccd05f7e1a63d0b07522a9c"
 dependencies = [
  "bs58",
  "constant_time_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ sqlx = { version = "0.6.3", features = ["chrono", "postgres", "runtime-actix-nat
 toml = { version = "0.8.12" }
 tokio = { version = "1.37.0", features = ["macros", "process", "rt"] }
 tokio-cron-scheduler = { version = "0.10.0", features = ["signal"]}
-prefixed-api-key = { version = "0.1.0", features = ["sha2"]}
+prefixed-api-key = { version = "0.2.0", features = ["sha2"]}
 prettytable-rs = { version = "0.10.0"}
 url = { version = "2.5.0", features = ["serde"] }
 urlencoding = { version = "2.1.3" }

--- a/src/server/tokens.rs
+++ b/src/server/tokens.rs
@@ -48,7 +48,7 @@ fn api_key_controller() -> Result<PrefixedApiKeyController<OsRng, Sha256>, AybEr
 }
 
 pub fn generate_api_token(entity: &InstantiatedEntity) -> Result<(APIToken, String), AybError> {
-    let mut controller = api_key_controller()?;
+    let controller = api_key_controller()?;
     let (pak, hash) = controller.generate_key_and_hash();
     Ok((
         APIToken {


### PR DESCRIPTION
Resolves #336 