### PR TITLE
Add support for S3 `force_path_style`; Introduce localstack for testing; remove debugging symbol details in Cargo.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tests/smtp_data_10025
 tests/smtp_data_10026
 tests/nsjail
 tests/localstack_init.sh
+tests/localstack_data*

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tests/ayb_data_sqlite
 tests/smtp_data_10025
 tests/smtp_data_10026
 tests/nsjail
+tests/localstack_init.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,3 @@ path = "src/bin/ayb.rs"
 [[bin]]
 name = "ayb_isolated_runner"
 path = "src/bin/ayb_isolated_runner.rs"
-
-[profile.dev]
-# debug = 2 uses too much memory and gets an OOM on marcua's tiny dev
-# server. See https://github.com/marcua/ayb/issues/342.
-debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,8 @@ path = "src/bin/ayb.rs"
 [[bin]]
 name = "ayb_isolated_runner"
 path = "src/bin/ayb_isolated_runner.rs"
+
+[profile.dev]
+# debug = 2 uses too much memory and gets an OOM on marcua's tiny dev
+# server. See https://github.com/marcua/ayb/issues/342.
+debug = 1

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -59,6 +59,10 @@ pub struct AybConfigSnapshots {
     pub path_prefix: String,
     pub endpoint_url: Option<String>,
     pub region: Option<String>,
+    // By default, AWS (and some S3-compatible providers) include
+    // bucket details in the domain/endpoint. Other tools like minio
+    // include the bucket in the path. When `force_path_style` is
+    // `true`, we include the bucket in the path.
     pub force_path_style: Option<bool>,
     pub automation: Option<AybConfigSnapshotsAutomation>,
 }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -62,7 +62,8 @@ pub struct AybConfigSnapshots {
     // By default, AWS (and some S3-compatible providers) include
     // bucket details in the domain/endpoint. Other tools like minio
     // include the bucket in the path. When `force_path_style` is
-    // `true`, we include the bucket in the path.
+    // `true` (it defaults to `false`), we include the bucket
+    // in the path.
     pub force_path_style: Option<bool>,
     pub automation: Option<AybConfigSnapshotsAutomation>,
 }

--- a/src/server/snapshots/storage.rs
+++ b/src/server/snapshots/storage.rs
@@ -40,7 +40,7 @@ impl SnapshotStorage {
         Ok(SnapshotStorage {
             bucket: config.bucket.clone(),
             client: aws_sdk_s3::Client::from_conf(s3_config),
-            force_path_style: force_path_style,
+            force_path_style,
             path_prefix: config.path_prefix.to_string(),
         })
     }

--- a/tests/localstack_server.sh
+++ b/tests/localstack_server.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir tests/localstack_data_$1
+source tests/localstack_data/test-env/bin/activate || python3 -m venv tests/localstack_data_$1/test-env && source tests/localstack_data_$1/test-env/bin/activate
+pip install localstack awscli
+echo "#!/bin/bash" > tests/localstack_init.sh
+echo "awslocal s3 mb s3://bucket$1" >> tests/localstack_init.sh
+chmod +x tests/localstack_init.sh
+SCRIPT_PATH=$(realpath "tests/localstack_init.sh")
+DOCKER_FLAGS="-v ${SCRIPT_PATH}:/etc/localstack/init/ready.d/init-aws.sh" localstack start -d --network ls


### PR DESCRIPTION
* This PR starts to introduce [localstack](https://docs.localstack.cloud/getting-started/quickstart/) to make it easier to test S3-reliant functionality like uploading database snapshots as part of #14
* It also implements an optional `force_path_style` flag (default false), which enables us to use [path-style requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html) to S3-compatible storage (seems to be a requirement for minio and localstack)
* Finally, it resolves #342 by removing some instructions on changing the default debugging symbol level in builds. The root cause was a mix of misconfigured localstack and lack of swap space.