### PR TITLE
Ability to restore from a snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,7 @@ dependencies = [
  "toml",
  "url",
  "urlencoding",
+ "uuid",
  "walkdir",
 ]
 
@@ -4574,9 +4575,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand",
  "hex",
  "http 0.2.9",
  "hyper 0.14.26",
@@ -496,7 +496,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand",
  "http 0.2.9",
  "http-body 0.4.5",
  "percent-encoding",
@@ -526,7 +526,7 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand",
  "hex",
  "hmac",
  "http 0.2.9",
@@ -730,7 +730,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand",
  "h2 0.3.26",
  "http 0.2.9",
  "http-body 0.4.5",
@@ -1571,23 +1571,12 @@ checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1616,15 +1605,6 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
@@ -1636,7 +1616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix 0.38.25",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -2528,7 +2508,7 @@ dependencies = [
  "chumsky",
  "email-encoding",
  "email_address",
- "fastrand 2.0.1",
+ "fastrand",
  "futures-io",
  "futures-util",
  "hostname",
@@ -3273,15 +3253,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -3540,15 +3511,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.13",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4198,15 +4169,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 1.9.0",
- "redox_syscall 0.3.5",
- "rustix 0.37.25",
- "windows-sys 0.45.0",
+ "fastrand",
+ "rustix 0.38.34",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ prefixed-api-key = { version = "0.2.0", features = ["sha2"]}
 prettytable-rs = { version = "0.10.0"}
 url = { version = "2.5.1", features = ["serde"] }
 urlencoding = { version = "2.1.3" }
+uuid = { version = "1.9.1", features = ["v7"] }
 walkdir = { version = "2.5.0" }
 
 [dev-dependencies]

--- a/src/client/cli.rs
+++ b/src/client/cli.rs
@@ -198,7 +198,7 @@ pub fn client_commands() -> Command {
                      .value_parser(ValueParser::new(entity_database_parser))
                      .required(true)
                 )
-                .arg(arg!(<snapshot_name> "The name of the snapshot to load").required(true))               )
+                .arg(arg!(<snapshot_id> "The name of the snapshot to load").required(true))               )
 }
 
 pub async fn execute_client_command(matches: &ArgMatches) -> std::io::Result<()> {
@@ -462,22 +462,22 @@ pub async fn execute_client_command(matches: &ArgMatches) -> std::io::Result<()>
             }
         }
     } else if let Some(matches) = matches.subcommand_matches("restore_snapshot") {
-        if let (Some(entity_database), Some(snapshot_name)) = (
+        if let (Some(entity_database), Some(snapshot_id)) = (
             matches.get_one::<EntityDatabasePath>("database"),
-            matches.get_one::<String>("snapshot_name"),
+            matches.get_one::<String>("snapshot_id"),
         ) {
             match client
                 .restore_snapshot(
                     &entity_database.entity,
                     &entity_database.database,
-                    snapshot_name,
+                    snapshot_id,
                 )
                 .await
             {
                 Ok(_response) => {
                     println!(
                         "Restored {}/{} to snapshot {}",
-                        entity_database.entity, entity_database.database, snapshot_name
+                        entity_database.entity, entity_database.database, snapshot_id
                     );
                 }
                 Err(err) => {

--- a/src/client/cli.rs
+++ b/src/client/cli.rs
@@ -193,7 +193,7 @@ pub fn client_commands() -> Command {
         )
         .subcommand(
             Command::new("restore_snapshot")
-                .about("Load a different snapshot/backup of a database")
+                .about("Restore a database to a particular snapshot/backup")
                 .arg(arg!(<database> "The database for which to load a snapshot (e.g., entity/database.sqlite)")
                      .value_parser(ValueParser::new(entity_database_parser))
                      .required(true)

--- a/src/client/cli.rs
+++ b/src/client/cli.rs
@@ -191,6 +191,14 @@ pub fn client_commands() -> Command {
                         .default_value(OutputFormat::Table.to_str())
                         .required(false))
         )
+        .subcommand(
+            Command::new("restore_snapshot")
+                .about("Load a different snapshot/backup of a database")
+                .arg(arg!(<database> "The database for which to load a snapshot (e.g., entity/database.sqlite)")
+                     .value_parser(ValueParser::new(entity_database_parser))
+                     .required(true)
+                )
+                .arg(arg!(<snapshot_name> "The name of the snapshot to load").required(true))               )
 }
 
 pub async fn execute_client_command(matches: &ArgMatches) -> std::io::Result<()> {
@@ -447,6 +455,30 @@ pub async fn execute_client_command(matches: &ArgMatches) -> std::io::Result<()>
                             OutputFormat::Csv => response.snapshots.generate_csv()?,
                         }
                     }
+                }
+                Err(err) => {
+                    println!("Error: {}", err);
+                }
+            }
+        }
+    } else if let Some(matches) = matches.subcommand_matches("restore_snapshot") {
+        if let (Some(entity_database), Some(snapshot_name)) = (
+            matches.get_one::<EntityDatabasePath>("database"),
+            matches.get_one::<String>("snapshot_name"),
+        ) {
+            match client
+                .restore_snapshot(
+                    &entity_database.entity,
+                    &entity_database.database,
+                    snapshot_name,
+                )
+                .await
+            {
+                Ok(_response) => {
+                    println!(
+                        "Restored {}/{} to snapshot {}",
+                        entity_database.entity, entity_database.database, snapshot_name
+                    );
                 }
                 Err(err) => {
                     println!("Error: {}", err);

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -117,26 +117,6 @@ impl AybClient {
             .await
     }
 
-    pub async fn restore_snapshot(
-        &self,
-        entity: &str,
-        database: &str,
-        snapshot_name: &str,
-    ) -> Result<(), AybError> {
-        let mut headers = HeaderMap::new();
-        self.add_bearer_token(&mut headers)?;
-
-        let response = reqwest::Client::new()
-            .post(self.make_url(format!("{}/{}/restore_snapshot", entity, database)))
-            .headers(headers)
-            .body(snapshot_name.to_owned())
-            .send()
-            .await?;
-
-        self.handle_response(response, reqwest::StatusCode::OK)
-            .await
-    }
-
     pub async fn list_snapshots(
         &self,
         entity: &str,
@@ -233,6 +213,26 @@ impl AybClient {
             .await?;
 
         self.handle_response(response, reqwest::StatusCode::OK)
+            .await
+    }
+
+    pub async fn restore_snapshot(
+        &self,
+        entity: &str,
+        database: &str,
+        snapshot_id: &str,
+    ) -> Result<(), AybError> {
+        let mut headers = HeaderMap::new();
+        self.add_bearer_token(&mut headers)?;
+
+        let response = reqwest::Client::new()
+            .post(self.make_url(format!("{}/{}/restore_snapshot", entity, database)))
+            .headers(headers)
+            .body(snapshot_id.to_owned())
+            .send()
+            .await?;
+
+        self.handle_empty_response(response, reqwest::StatusCode::OK)
             .await
     }
 

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -117,6 +117,26 @@ impl AybClient {
             .await
     }
 
+    pub async fn restore_snapshot(
+        &self,
+        entity: &str,
+        database: &str,
+        snapshot_name: &str,
+    ) -> Result<(), AybError> {
+        let mut headers = HeaderMap::new();
+        self.add_bearer_token(&mut headers)?;
+
+        let response = reqwest::Client::new()
+            .post(self.make_url(format!("{}/{}/restore_snapshot", entity, database)))
+            .headers(headers)
+            .body(snapshot_name.to_owned())
+            .send()
+            .await?;
+
+        self.handle_response(response, reqwest::StatusCode::OK)
+            .await
+    }
+
     pub async fn list_snapshots(
         &self,
         entity: &str,

--- a/src/hosted_db/paths.rs
+++ b/src/hosted_db/paths.rs
@@ -1,7 +1,11 @@
 use crate::error::AybError;
 use std::fs;
+use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
+use uuid::{timestamp::context::ContextV7, Timestamp, Uuid};
 
+pub const CURRENT: &str = "current";
+pub const CURRENT_TMP: &str = "current.tmp";
 const DATABASES: &str = "databases";
 const SNAPSHOTS: &str = "snapshots";
 
@@ -21,31 +25,71 @@ pub fn database_parent_path(data_path: &str, create_path: bool) -> Result<PathBu
     Ok(fs::canonicalize(path)?)
 }
 
-pub fn database_path(
+/// Returns a path for a new database directory for storing
+/// `{entity_slug}/{database_slug}`. The format for this path is
+/// `{data_path}/{entity_slug}/{database_slug}/{time_sortable_uuid}/`.
+pub fn new_database_path(
     entity_slug: &str,
     database_slug: &str,
     data_path: &str,
-    create_database: bool,
 ) -> Result<PathBuf, AybError> {
+    let uuid = Uuid::new_v7(Timestamp::now(ContextV7::new()));
     // We place each database in its own directory because databases
     // might span multiple files (e.g, the SQLite database file as
     // well as a journal/write-ahead log).
-    let mut path: PathBuf = [data_path, DATABASES, entity_slug, database_slug]
-        .iter()
-        .collect();
-    if create_database {
-        if let Err(e) = fs::create_dir_all(&path) {
-            return Err(AybError::Other {
-                message: format!("Unable to create entity path for {}: {}", entity_slug, e),
-            });
-        }
-    }
+    let path: PathBuf = [
+        data_path,
+        DATABASES,
+        entity_slug,
+        database_slug,
+        &uuid.to_string(),
+    ]
+    .iter()
+    .collect();
 
+    Ok(path)
+}
+
+/// Returns a path to a new database location (the file for the future
+/// database inside a newly created directory) after creating a
+/// directory and empty file in the future location of that database.
+pub fn instantiated_new_database_path(
+    entity_slug: &str,
+    database_slug: &str,
+    data_path: &str,
+) -> Result<PathBuf, AybError> {
+    let mut path = new_database_path(entity_slug, database_slug, data_path)?;
+    if let Err(e) = fs::create_dir_all(&path) {
+        return Err(AybError::Other {
+            message: format!("Unable to create entity path for {}: {}", entity_slug, e),
+        });
+    }
     path.push(database_slug);
 
-    if create_database && !path.exists() {
+    if !path.exists() {
         fs::File::create(path.clone())?;
     }
+
+    Ok(fs::canonicalize(path)?)
+}
+
+pub fn current_database_path(
+    entity_slug: &str,
+    database_slug: &str,
+    data_path: &str,
+) -> Result<PathBuf, AybError> {
+    // `current` is a symlink to the database directory containing the
+    // most recently restored/created version of the database.
+    let path: PathBuf = [
+        data_path,
+        DATABASES,
+        entity_slug,
+        database_slug,
+        CURRENT,
+        database_slug,
+    ]
+    .iter()
+    .collect();
 
     Ok(fs::canonicalize(path)?)
 }
@@ -97,4 +141,30 @@ pub fn pathbuf_to_parent(path: &Path) -> Result<PathBuf, AybError> {
             message: format!("Unable to find parent directory of {}", path.display()),
         })?
         .to_owned())
+}
+
+/// Declares `new_path` as the new current path (by symlinking the
+/// current path to it) and, if a previous database existed as the
+/// current database, delete it.
+pub fn set_current_database_and_clean_up(new_path: &Path) -> Result<(), AybError> {
+    let mut current_db_path = pathbuf_to_parent(new_path)?;
+    let mut current_tmp_db_path = current_db_path.clone();
+    current_db_path.push(CURRENT);
+    current_tmp_db_path.push(CURRENT_TMP);
+    let previous_database_path = fs::canonicalize(current_db_path.clone());
+
+    // TODO(marcua): This `symlink` call is the Unix API. Consider
+    // Windows support in the future.
+    symlink(fs::canonicalize(new_path)?, current_tmp_db_path.clone())?;
+    // Why create a temporary current symlink and then rename it? This
+    // is apparently how one overwrites a symlink. See
+    // https://stackoverflow.com/questions/37345844/how-to-overwrite-a-symlink-in-go.
+    fs::rename(current_tmp_db_path, current_db_path)?;
+
+    // Remove previous path if it existed.
+    if let Ok(previous_database_path) = previous_database_path {
+        fs::remove_dir_all(previous_database_path)?;
+    }
+
+    Ok(())
 }

--- a/src/hosted_db/paths.rs
+++ b/src/hosted_db/paths.rs
@@ -30,7 +30,7 @@ pub fn database_parent_path(data_path: &str, create_path: bool) -> Result<PathBu
 
 /// Returns a path for a new database directory for storing
 /// `{entity_slug}/{database_slug}`. The format for this path is
-/// `{data_path}/{entity_slug}/{database_slug}/{time_sortable_uuid}/`.
+/// `{data_path}/databases/{entity_slug}/{database_slug}/{time_sortable_uuid}/`.
 pub fn new_database_path(
     entity_slug: &str,
     database_slug: &str,
@@ -99,18 +99,22 @@ pub fn current_database_path(
     Ok(fs::canonicalize(path)?)
 }
 
+/// Returns a path for a new database snapshot directory for storing a
+/// snapshot of `{entity_slug}/{database_slug}`. The format for this
+/// path is
+/// `{data_path}/snapshots/{entity_slug}/{database_slug}/{time_sortable_uuid}/`.
 pub fn database_snapshot_path(
     entity_slug: &str,
     database_slug: &str,
-    snapshot_slug: &str,
     data_path: &str,
 ) -> Result<PathBuf, AybError> {
+    let uuid = Uuid::new_v7(Timestamp::now(ContextV7::new()));
     let path: PathBuf = [
         data_path,
         SNAPSHOTS,
         entity_slug,
         database_slug,
-        snapshot_slug,
+        &uuid.to_string(),
     ]
     .iter()
     .collect();

--- a/src/hosted_db/paths.rs
+++ b/src/hosted_db/paths.rs
@@ -49,6 +49,14 @@ pub fn new_database_path(
     ]
     .iter()
     .collect();
+    if let Err(e) = fs::create_dir_all(&path) {
+        return Err(AybError::Other {
+            message: format!(
+                "Unable to create database path for {}/{}: {}",
+                entity_slug, database_slug, e
+            ),
+        });
+    }
 
     Ok(path)
 }
@@ -62,13 +70,7 @@ pub fn instantiated_new_database_path(
     data_path: &str,
 ) -> Result<PathBuf, AybError> {
     let mut path = new_database_path(entity_slug, database_slug, data_path)?;
-    if let Err(e) = fs::create_dir_all(&path) {
-        return Err(AybError::Other {
-            message: format!("Unable to create entity path for {}: {}", entity_slug, e),
-        });
-    }
     path.push(database_slug);
-
     if !path.exists() {
         fs::File::create(path.clone())?;
     }

--- a/src/http/structs.rs
+++ b/src/http/structs.rs
@@ -186,7 +186,7 @@ impl TabularFormatter for Vec<ListSnapshotResult> {
         self.iter()
             .map(|v| {
                 Row::new(vec![
-                    Cell::new(&v.name),
+                    Cell::new(&v.snapshot_id),
                     Cell::new(&v.last_modified_at.to_string()),
                 ])
             })

--- a/src/server/endpoints/mod.rs
+++ b/src/server/endpoints/mod.rs
@@ -5,6 +5,7 @@ mod list_snapshots;
 mod log_in;
 mod query;
 mod register;
+mod restore_snapshot;
 mod update_profile;
 
 pub use confirm::confirm as confirm_endpoint;
@@ -14,4 +15,5 @@ pub use list_snapshots::list_snapshots as list_snapshots_endpoint;
 pub use log_in::log_in as log_in_endpoint;
 pub use query::query as query_endpoint;
 pub use register::register as register_endpoint;
+pub use restore_snapshot::restore_snapshot as restore_snapshot_endpoint;
 pub use update_profile::update_profile as update_profile_endpoint;

--- a/src/server/endpoints/query.rs
+++ b/src/server/endpoints/query.rs
@@ -2,7 +2,7 @@ use crate::ayb_db::db_interfaces::AybDb;
 use crate::ayb_db::models::{DBType, InstantiatedEntity};
 
 use crate::error::AybError;
-use crate::hosted_db::paths::database_path;
+use crate::hosted_db::paths::current_database_path;
 use crate::hosted_db::{run_query, QueryResult};
 use crate::http::structs::EntityDatabasePath;
 use crate::server::config::AybConfig;
@@ -25,7 +25,7 @@ async fn query(
 
     if can_query(&authenticated_entity, &database) {
         let db_type = DBType::try_from(database.db_type)?;
-        let db_path = database_path(entity_slug, database_slug, &ayb_config.data_path, false)?;
+        let db_path = current_database_path(entity_slug, database_slug, &ayb_config.data_path)?;
         let result = run_query(&db_path, &query, &db_type, &ayb_config.isolation).await?;
         Ok(web::Json(result))
     } else {

--- a/src/server/endpoints/restore_snapshot.rs
+++ b/src/server/endpoints/restore_snapshot.rs
@@ -34,7 +34,7 @@ async fn restore_snapshot(
             let snapshot_storage = SnapshotStorage::new(snapshot_config).await?;
             let db_path = &new_database_path(entity_slug, database_slug, &ayb_config.data_path)?;
             snapshot_storage
-                .retrieve_snapshot(entity_slug, database_slug, &snapshot_id, &db_path)
+                .retrieve_snapshot(entity_slug, database_slug, &snapshot_id, db_path)
                 .await?;
             set_current_database_and_clean_up(db_path)?;
         }

--- a/src/server/endpoints/restore_snapshot.rs
+++ b/src/server/endpoints/restore_snapshot.rs
@@ -1,16 +1,13 @@
 use crate::ayb_db::db_interfaces::AybDb;
 use crate::ayb_db::models::InstantiatedEntity;
 use crate::error::AybError;
-use crate::hosted_db::paths::{
-    new_database_path, pathbuf_to_parent, set_current_database_and_clean_up,
-};
+use crate::hosted_db::paths::{new_database_path, set_current_database_and_clean_up};
 use crate::http::structs::{EmptyResponse, EntityDatabasePath};
 use crate::server::config::AybConfig;
 use crate::server::permissions::can_manage_snapshots;
 use crate::server::snapshots::storage::SnapshotStorage;
 use crate::server::utils::unwrap_authenticated_entity;
 use actix_web::{post, web, HttpResponse};
-use std::fs::rename;
 
 #[post("/v1/{entity}/{database}/restore_snapshot")]
 async fn restore_snapshot(
@@ -35,20 +32,10 @@ async fn restore_snapshot(
             // Retrieve the snapshot, move it to the active databases
             // directory, and set it as the current active database.
             let snapshot_storage = SnapshotStorage::new(snapshot_config).await?;
-            // TODO(marcua): Consider passing a path to
-            // retrieve_snapshot so it creates the file there.
-            let snapshot_path = pathbuf_to_parent(
-                &snapshot_storage
-                    .retrieve_snapshot(
-                        entity_slug,
-                        database_slug,
-                        &snapshot_id,
-                        &ayb_config.data_path,
-                    )
-                    .await?,
-            )?;
             let db_path = &new_database_path(entity_slug, database_slug, &ayb_config.data_path)?;
-            rename(snapshot_path, db_path.clone())?;
+            snapshot_storage
+                .retrieve_snapshot(entity_slug, database_slug, &snapshot_id, &db_path)
+                .await?;
             set_current_database_and_clean_up(db_path)?;
         }
         Ok(HttpResponse::Ok().json(EmptyResponse {}))

--- a/src/server/endpoints/restore_snapshot.rs
+++ b/src/server/endpoints/restore_snapshot.rs
@@ -1,0 +1,61 @@
+use crate::ayb_db::db_interfaces::AybDb;
+use crate::ayb_db::models::InstantiatedEntity;
+use crate::error::AybError;
+use crate::hosted_db::paths::{database_path, pathbuf_to_parent};
+use crate::http::structs::{EmptyResponse, EntityDatabasePath};
+use crate::server::config::AybConfig;
+use crate::server::permissions::can_manage_snapshots;
+use crate::server::snapshots::storage::SnapshotStorage;
+use crate::server::utils::unwrap_authenticated_entity;
+use actix_web::{post, web, HttpResponse};
+use std::fs::rename;
+
+#[post("/v1/{entity}/{database}/restore_snapshot")]
+async fn restore_snapshot(
+    path: web::Path<EntityDatabasePath>,
+    snapshot_id: String,
+    ayb_db: web::Data<Box<dyn AybDb>>,
+    ayb_config: web::Data<AybConfig>,
+    authenticated_entity: Option<web::ReqData<InstantiatedEntity>>,
+) -> Result<HttpResponse, AybError> {
+    let entity_slug = &path.entity.to_lowercase();
+    let database_slug = &path.database;
+    let database = ayb_db.get_database(entity_slug, database_slug).await?;
+    let authenticated_entity = unwrap_authenticated_entity(&authenticated_entity)?;
+    
+    if can_manage_snapshots(&authenticated_entity, &database) {
+        if let Some(ref snapshot_config) = ayb_config.snapshots {
+            // TODO(marcua): In the future, consider quiesting
+            // requests to this database during the process, and
+            // locking so that only one snapshot per database can be
+            // restored at a time.
+
+            let snapshot_storage = SnapshotStorage::new(snapshot_config).await?;
+            let snapshot_path = snapshot_storage
+                .retrieve_snapshot(
+                    entity_slug,
+                    database_slug,
+                    &snapshot_id,
+                    &ayb_config.data_path,
+                )
+                .await?;
+            let db_path =
+                database_path(&entity_slug, &database_slug, &ayb_config.data_path, false)?;
+            // Atomically rename the directory holding the restored
+            // snapshot file to the directory holding the active
+            // database.
+            rename(
+                pathbuf_to_parent(&snapshot_path)?,
+                pathbuf_to_parent(&db_path)?,
+            )?;
+        }
+        Ok(HttpResponse::Ok().json(EmptyResponse {}))
+    } else {
+        Err(AybError::Other {
+            message: format!(
+                "Authenticated entity {} can not manage snapshots on database {}/{}",
+                authenticated_entity.slug, entity_slug, database_slug
+            ),
+        })
+    }
+}

--- a/src/server/endpoints/restore_snapshot.rs
+++ b/src/server/endpoints/restore_snapshot.rs
@@ -1,7 +1,9 @@
 use crate::ayb_db::db_interfaces::AybDb;
 use crate::ayb_db::models::InstantiatedEntity;
 use crate::error::AybError;
-use crate::hosted_db::paths::{database_path, pathbuf_to_parent};
+use crate::hosted_db::paths::{
+    new_database_path, pathbuf_to_parent, set_current_database_and_clean_up,
+};
 use crate::http::structs::{EmptyResponse, EntityDatabasePath};
 use crate::server::config::AybConfig;
 use crate::server::permissions::can_manage_snapshots;
@@ -22,32 +24,32 @@ async fn restore_snapshot(
     let database_slug = &path.database;
     let database = ayb_db.get_database(entity_slug, database_slug).await?;
     let authenticated_entity = unwrap_authenticated_entity(&authenticated_entity)?;
-    
+
     if can_manage_snapshots(&authenticated_entity, &database) {
         if let Some(ref snapshot_config) = ayb_config.snapshots {
-            // TODO(marcua): In the future, consider quiesting
+            // TODO(marcua): In the future, consider quiescing
             // requests to this database during the process, and
             // locking so that only one snapshot per database can be
             // restored at a time.
 
+            // Retrieve the snapshot, move it to the active databases
+            // directory, and set it as the current active database.
             let snapshot_storage = SnapshotStorage::new(snapshot_config).await?;
-            let snapshot_path = snapshot_storage
-                .retrieve_snapshot(
-                    entity_slug,
-                    database_slug,
-                    &snapshot_id,
-                    &ayb_config.data_path,
-                )
-                .await?;
-            let db_path =
-                database_path(&entity_slug, &database_slug, &ayb_config.data_path, false)?;
-            // Atomically rename the directory holding the restored
-            // snapshot file to the directory holding the active
-            // database.
-            rename(
-                pathbuf_to_parent(&snapshot_path)?,
-                pathbuf_to_parent(&db_path)?,
+            // TODO(marcua): Consider passing a path to
+            // retrieve_snapshot so it creates the file there.
+            let snapshot_path = pathbuf_to_parent(
+                &snapshot_storage
+                    .retrieve_snapshot(
+                        entity_slug,
+                        database_slug,
+                        &snapshot_id,
+                        &ayb_config.data_path,
+                    )
+                    .await?,
             )?;
+            let db_path = &new_database_path(&entity_slug, &database_slug, &ayb_config.data_path)?;
+            rename(snapshot_path, db_path.clone())?;
+            set_current_database_and_clean_up(&db_path)?;
         }
         Ok(HttpResponse::Ok().json(EmptyResponse {}))
     } else {

--- a/src/server/endpoints/restore_snapshot.rs
+++ b/src/server/endpoints/restore_snapshot.rs
@@ -47,9 +47,9 @@ async fn restore_snapshot(
                     )
                     .await?,
             )?;
-            let db_path = &new_database_path(&entity_slug, &database_slug, &ayb_config.data_path)?;
+            let db_path = &new_database_path(entity_slug, database_slug, &ayb_config.data_path)?;
             rename(snapshot_path, db_path.clone())?;
-            set_current_database_and_clean_up(&db_path)?;
+            set_current_database_and_clean_up(db_path)?;
         }
         Ok(HttpResponse::Ok().json(EmptyResponse {}))
     } else {

--- a/src/server/server_runner.rs
+++ b/src/server/server_runner.rs
@@ -5,7 +5,8 @@ use crate::server::config::read_config;
 use crate::server::config::AybConfigCors;
 use crate::server::endpoints::{
     confirm_endpoint, create_db_endpoint, entity_details_endpoint, list_snapshots_endpoint,
-    log_in_endpoint, query_endpoint, register_endpoint, update_profile_endpoint,
+    log_in_endpoint, query_endpoint, register_endpoint, restore_snapshot_endpoint,
+    update_profile_endpoint,
 };
 use crate::server::snapshots::schedule_periodic_snapshots;
 use crate::server::tokens::retrieve_and_validate_api_token;
@@ -30,7 +31,8 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             .service(query_endpoint)
             .service(entity_details_endpoint)
             .service(update_profile_endpoint)
-            .service(list_snapshots_endpoint),
+            .service(list_snapshots_endpoint)
+            .service(restore_snapshot_endpoint),
     );
 }
 
@@ -105,6 +107,7 @@ pub async fn run_server(config_path: &PathBuf) -> std::io::Result<()> {
         let cors = build_cors(ayb_conf.cors.clone());
 
         App::new()
+            .wrap(middleware::Logger::default())
             .wrap(middleware::Compress::default())
             .wrap(cors)
             .configure(config)

--- a/src/server/snapshots.rs
+++ b/src/server/snapshots.rs
@@ -4,7 +4,7 @@ pub mod storage;
 use crate::ayb_db::db_interfaces::AybDb;
 use crate::error::AybError;
 use crate::hosted_db::paths::{
-    database_parent_path, database_path, database_snapshot_path, pathbuf_to_file_name,
+    current_database_path, database_parent_path, database_snapshot_path, pathbuf_to_file_name,
     pathbuf_to_parent,
 };
 use crate::hosted_db::sqlite::query_sqlite;
@@ -12,6 +12,7 @@ use crate::server::config::{AybConfig, SqliteSnapshotMethod};
 use crate::server::snapshots::models::{Snapshot, SnapshotType};
 use crate::server::snapshots::storage::SnapshotStorage;
 use go_parse_duration::parse_duration;
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::time::Duration;
@@ -38,7 +39,12 @@ pub async fn schedule_periodic_snapshots(
                     let config = config.clone();
                     let ayb_db = ayb_db.clone();
                     Box::pin(async move {
-                        create_snapshots(&config.clone(), &ayb_db.clone()).await;
+                        if let Some(err) = create_snapshots(&config.clone(), &ayb_db.clone())
+                            .await
+                            .err()
+                        {
+                            eprintln!("Unable to walk database directory for snapshots: {}", err);
+                        }
                     })
                 })?)
                 .await?;
@@ -55,18 +61,25 @@ pub async fn schedule_periodic_snapshots(
 // unimplemented trait compiler error, but if I keep it, I get a
 // Clippy warning.
 #[allow(clippy::borrowed_box)]
-async fn create_snapshots(config: &AybConfig, ayb_db: &Box<dyn AybDb>) {
+async fn create_snapshots(config: &AybConfig, ayb_db: &Box<dyn AybDb>) -> Result<(), AybError> {
     // Walk the data path for entity slugs, database slugs
+    println!("Creating snapshots...");
+    let mut visited: HashSet<String> = HashSet::new();
     for entry in WalkDir::new(database_parent_path(&config.data_path, true).unwrap())
         .into_iter()
         .filter_map(|e| e.ok())
-        .filter(|e| !e.file_type().is_dir())
+        .filter(|e| !e.file_type().is_dir() && !e.path_is_symlink())
     {
         let path = entry.path();
-        if let Some(err) = snapshot_database(config, ayb_db, path).await.err() {
+        if let Some(err) = snapshot_database(config, ayb_db, path, &mut visited)
+            .await
+            .err()
+        {
             eprintln!("Unable to snapshot database {}: {}", path.display(), err);
         }
     }
+
+    Ok(())
 }
 
 #[allow(clippy::borrowed_box)]
@@ -74,12 +87,23 @@ pub async fn snapshot_database(
     config: &AybConfig,
     ayb_db: &Box<dyn AybDb>,
     path: &Path,
+    visited: &mut HashSet<String>,
 ) -> Result<(), AybError> {
     // TODO(marcua): Replace printlns with some structured logging or
     // tracing library.
     println!("Trying to back up {}", path.display());
-    let entity_slug = pathbuf_to_file_name(&pathbuf_to_parent(&pathbuf_to_parent(path)?)?)?;
+    let entity_slug = pathbuf_to_file_name(&pathbuf_to_parent(&pathbuf_to_parent(
+        &pathbuf_to_parent(path)?,
+    )?)?)?;
     let database_slug = pathbuf_to_file_name(path)?;
+    let visited_path = format!("{}/{}", entity_slug, database_slug);
+    if visited.contains(&visited_path) {
+        // We only need to snapshot each database once per run, but we
+        // might encounter multiple versions of the database. Return
+        // early if we've already taken a backup.
+        return Ok(());
+    }
+    visited.insert(visited_path);
     if config.snapshots.is_none() {
         return Err(AybError::SnapshotError {
             message: "No snapshot config found".to_string(),
@@ -88,12 +112,11 @@ pub async fn snapshot_database(
     let snapshot_config = config.snapshots.as_ref().unwrap();
 
     match ayb_db.get_database(&entity_slug, &database_slug).await {
-        Ok(db) => {
-            println!("Hashing {} {}", entity_slug, database_slug);
+        Ok(_db) => {
             // TODO(marcua): Implement hashing. `.sha3sum --schema` is
             // only available at the SQLite command line since it's a
             // dot command.
-            let db_path = database_path(&entity_slug, &database_slug, &config.data_path, false)?;
+            let db_path = current_database_path(&entity_slug, &database_slug, &config.data_path)?;
             // TODO(marcua): Do better than "temporary"
             // by creating a tmpdir.
             let mut snapshot_path = database_snapshot_path(
@@ -117,7 +140,6 @@ pub async fn snapshot_database(
                     format!("VACUUM INTO \"{}\"", snapshot_path.display())
                 }
             };
-            println!("Running {}", backup_query);
             let result = query_sqlite(
                 &db_path,
                 &backup_query,
@@ -147,7 +169,6 @@ pub async fn snapshot_database(
                     &Snapshot {
                         pre_snapshot_hash: "notimplemented".to_string(),
                         snapshot_hash: "notimplemented".to_string(),
-                        database_id: db.id,
                         snapshot_type: SnapshotType::Automatic as i16,
                     },
                     &snapshot_path,

--- a/src/server/snapshots.rs
+++ b/src/server/snapshots.rs
@@ -117,14 +117,8 @@ pub async fn snapshot_database(
             // only available at the SQLite command line since it's a
             // dot command.
             let db_path = current_database_path(&entity_slug, &database_slug, &config.data_path)?;
-            // TODO(marcua): Do better than "temporary"
-            // by creating a tmpdir.
-            let mut snapshot_path = database_snapshot_path(
-                &entity_slug,
-                &database_slug,
-                "temporary",
-                &config.data_path,
-            )?;
+            let mut snapshot_path =
+                database_snapshot_path(&entity_slug, &database_slug, &config.data_path)?;
             snapshot_path.push(&database_slug);
             // Try to remove the file if it already exists, but don't fail if it doesn't.
             fs::remove_file(&snapshot_path).ok();
@@ -182,7 +176,7 @@ pub async fn snapshot_database(
             println!("Completed snapshot");
 
             // Clean up after uploading snapshot.
-            fs::remove_file(&snapshot_path).ok();
+            fs::remove_dir_all(&pathbuf_to_parent(&snapshot_path)?)?;
         }
         Err(err) => match err {
             AybError::RecordNotFound { record_type, .. } if record_type == "database" => {

--- a/src/server/snapshots.rs
+++ b/src/server/snapshots.rs
@@ -176,7 +176,7 @@ pub async fn snapshot_database(
             println!("Completed snapshot");
 
             // Clean up after uploading snapshot.
-            fs::remove_dir_all(&pathbuf_to_parent(&snapshot_path)?)?;
+            fs::remove_dir_all(pathbuf_to_parent(&snapshot_path)?)?;
         }
         Err(err) => match err {
             AybError::RecordNotFound { record_type, .. } if record_type == "database" => {

--- a/src/server/snapshots/models.rs
+++ b/src/server/snapshots/models.rs
@@ -52,7 +52,6 @@ pub struct Snapshot {
     // `snapshot_hash`.
     pub pre_snapshot_hash: String,
     pub snapshot_hash: String,
-    pub database_id: i32,
     pub snapshot_type: i16,
 }
 
@@ -76,16 +75,15 @@ impl Snapshot {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InstantiatedSnapshot {
-    pub created_at: DateTime<Utc>,
+    pub last_modified_at: DateTime<Utc>,
     // See Snapshot for a defintion of the two hash fields.
     pub pre_snapshot_hash: String,
     pub snapshot_hash: String,
-    pub database_id: i32,
     pub snapshot_type: i16,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListSnapshotResult {
     pub last_modified_at: DateTime<Utc>,
-    pub name: String,
+    pub snapshot_id: String,
 }

--- a/src/server/snapshots/storage.rs
+++ b/src/server/snapshots/storage.rs
@@ -191,7 +191,7 @@ impl SnapshotStorage {
                             })?
                             .clone();
                         let snapshot_id = key
-                            .rsplit_once("/")
+                            .rsplit_once('/')
                             .ok_or_else(|| AybError::S3ExecutionError {
                                 message: format!(
                                     "Unexpected key path {} on object: {:?}",

--- a/src/server/snapshots/storage.rs
+++ b/src/server/snapshots/storage.rs
@@ -11,7 +11,7 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use std::fs::File;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub struct SnapshotStorage {
     bucket: String,
@@ -119,10 +119,10 @@ impl SnapshotStorage {
         entity_slug: &str,
         database_slug: &str,
         snapshot_id: &str,
-        destination_path: &PathBuf,
+        destination_path: &Path,
     ) -> Result<(), AybError> {
         let s3_path = self.db_path(entity_slug, database_slug, snapshot_id);
-        let mut snapshot_path = destination_path.clone();
+        let mut snapshot_path = destination_path.to_path_buf();
         snapshot_path.push(database_slug);
 
         let response = self

--- a/tests/e2e_tests/snapshot_tests.rs
+++ b/tests/e2e_tests/snapshot_tests.rs
@@ -37,10 +37,7 @@ pub async fn test_snapshots(
 
     // We'll sleep between various checks in this test to allow the
     // snapshotting logic, which runs every 2 seconds, to execute.
-    let snapshot_result_line = format!(
-        r"bucket\/{}\/e2e-first\/test.sqlite\/notimplemented,\d{{4,5}}-\d{{2}}-\d{{2}} \d{{2}}:\d{{2}}:\d{{2}} UTC",
-        db_type
-    );
+    let snapshot_result_line = r"notimplemented,\d{4,5}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC";
     thread::sleep(time::Duration::from_secs(3));
     list_snapshots(
         &config_path,
@@ -103,7 +100,7 @@ pub async fn test_snapshots(
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
         "notimplemented", // TODO(marcua): Replace with snapshot ID when we implement hashing.
-        "Restored snapshot replaceme",
+        "Restored e2e-first/test.sqlite to snapshot notimplemented",
     )?;
     query(
         &config_path,
@@ -114,6 +111,5 @@ pub async fn test_snapshots(
         " the_count \n-----------\n 3 \n\nRows: 1",
     )?;
 
-    // TODO(marcua): Should it be called snapshot name or snapshot ID or snapshot slug or snapshot hash? snapshot_id, and also rename ListSnapshotResult to have an id instead of a name.
     Ok(())
 }

--- a/tests/utils/ayb.rs
+++ b/tests/utils/ayb.rs
@@ -115,6 +115,21 @@ pub fn list_snapshots(
     Ok(())
 }
 
+pub fn restore_snapshot(
+    config: &str,
+    api_key: &str,
+    database: &str,
+    snapshot_name: &str,
+    result: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cmd = ayb_assert_cmd!("client", "--config", config, "restore_snapshot", database, snapshot_name; {
+        "AYB_API_TOKEN" => api_key,
+    });
+
+    cmd.stdout(format!("{}\n", result));
+    Ok(())
+}
+
 pub fn profile(
     config: &str,
     api_key: &str,

--- a/tests/utils/ayb.rs
+++ b/tests/utils/ayb.rs
@@ -119,10 +119,10 @@ pub fn restore_snapshot(
     config: &str,
     api_key: &str,
     database: &str,
-    snapshot_name: &str,
+    snapshot_id: &str,
     result: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let cmd = ayb_assert_cmd!("client", "--config", config, "restore_snapshot", database, snapshot_name; {
+    let cmd = ayb_assert_cmd!("client", "--config", config, "restore_snapshot", database, snapshot_id; {
         "AYB_API_TOKEN" => api_key,
     });
 


### PR DESCRIPTION
This PR introduces the ability to restore a database from a snapshot stored in S3-compatible storage as part of #14.
* It introduces a `retrieve_snapshot` endpoint on the client and server, including end-to-end tests of that experience
* In order to do this in a standard way, it introduces some new path convenience functions
* It also renames some previously non-specific properties of snapshots (in particular, `snapshot_name` -> `snapshot_id`)
* Finally, it resolves several outstanding TODOs in the code that were in tangentially related code