### PR TITLE
Identify snapshots by their hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +849,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-types-convert",
  "aws-types",
+ "blake3",
  "chrono",
  "clap",
  "derive_more",
@@ -936,6 +949,19 @@ name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "blake3"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d08263faac5cde2a4d52b513dadb80846023aade56fcd8fc99ba73ba8050e92"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.3.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1155,6 +1181,12 @@ name = "constant_time_eq"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "convert_case"
@@ -3026,7 +3058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a1392c6490debe7283eeb8fd424c41a5f9a2751ccd05f7e1a63d0b07522a9c"
 dependencies = [
  "bs58",
- "constant_time_eq",
+ "constant_time_eq 0.2.6",
  "digest",
  "hex",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ aws-credential-types = { version = "1.1.8", features = ["hardcoded-credentials"]
 aws-sdk-s3 = { version = "1.39.0" }
 aws-smithy-types-convert = { version = "0.60.8", features = ["convert-chrono"] }
 aws-types = { version = "1.3.0" }
+blake3 = { version = "1.5.2" }
 chrono = { version = "0.4.38", features = [ "serde" ] }
 clap = { version = "4.5.9", features = ["cargo", "derive", "env"] }
 derive_more = { version = "0.99.18" }

--- a/src/client/cli.rs
+++ b/src/client/cli.rs
@@ -198,7 +198,7 @@ pub fn client_commands() -> Command {
                      .value_parser(ValueParser::new(entity_database_parser))
                      .required(true)
                 )
-                .arg(arg!(<snapshot_id> "The name of the snapshot to load").required(true))               )
+                .arg(arg!(<snapshot_id> "The id of the snapshot to load").required(true))               )
 }
 
 pub async fn execute_client_command(matches: &ArgMatches) -> std::io::Result<()> {

--- a/src/http/structs.rs
+++ b/src/http/structs.rs
@@ -187,7 +187,7 @@ impl TabularFormatter for Vec<ListSnapshotResult> {
             .map(|v| {
                 Row::new(vec![
                     Cell::new(&v.snapshot_id),
-                    Cell::new(&v.last_modified_at.to_string()),
+                    Cell::new(&v.last_modified_at.to_rfc3339()),
                 ])
             })
             .for_each(|c| {

--- a/src/server/snapshots.rs
+++ b/src/server/snapshots.rs
@@ -1,3 +1,4 @@
+pub mod hashes;
 pub mod models;
 pub mod storage;
 
@@ -9,6 +10,7 @@ use crate::hosted_db::paths::{
 };
 use crate::hosted_db::sqlite::query_sqlite;
 use crate::server::config::{AybConfig, SqliteSnapshotMethod};
+use crate::server::snapshots::hashes::hash_db_directory;
 use crate::server::snapshots::models::{Snapshot, SnapshotType};
 use crate::server::snapshots::storage::SnapshotStorage;
 use go_parse_duration::parse_duration;

--- a/src/server/snapshots/hashes.rs
+++ b/src/server/snapshots/hashes.rs
@@ -1,0 +1,40 @@
+use crate::error::AybError;
+use blake3::Hasher;
+use std::fs;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+
+pub fn hash_db_directory(path: &Path) -> Result<String, AybError> {
+    let mut paths = fs::read_dir(path)?
+        .map(|entry| {
+            let entry_path = entry?.path();
+            if entry_path.is_file() {
+                Ok(entry_path)
+            } else {
+                Err(AybError::SnapshotError {
+                    message: format!(
+                        "Unexpected non-file path in database directory: {}",
+                        entry_path.display()
+                    ),
+                })
+            }
+        })
+        .collect::<Result<Vec<PathBuf>, AybError>>()?;
+    // Sort alphabetically to ensure determinism.
+    paths.sort_by(|a, b| a.cmp(b));
+
+    let mut hasher = Hasher::new();
+    for entry in paths {
+        let file = fs::File::open(entry)?;
+        let mut reader = BufReader::new(file);
+        let mut buffer = [0; 4096];
+        loop {
+            let bytes_read = reader.read(&mut buffer)?;
+            if bytes_read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..bytes_read]);
+        }
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}

--- a/src/server/snapshots/hashes.rs
+++ b/src/server/snapshots/hashes.rs
@@ -21,7 +21,7 @@ pub fn hash_db_directory(path: &Path) -> Result<String, AybError> {
         })
         .collect::<Result<Vec<PathBuf>, AybError>>()?;
     // Sort alphabetically to ensure determinism.
-    paths.sort_by(|a, b| a.cmp(b));
+    paths.sort();
 
     let mut hasher = Hasher::new();
     for entry in paths {

--- a/src/server/snapshots/hashes.rs
+++ b/src/server/snapshots/hashes.rs
@@ -20,7 +20,7 @@ pub fn hash_db_directory(path: &Path) -> Result<String, AybError> {
             }
         })
         .collect::<Result<Vec<PathBuf>, AybError>>()?;
-    // Sort alphabetically to ensure determinism.
+    // Sort alphabetically to ensure hash is deterministic.
     paths.sort();
 
     let mut hasher = Hasher::new();

--- a/src/server/snapshots/models.rs
+++ b/src/server/snapshots/models.rs
@@ -38,31 +38,14 @@ impl SnapshotType {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Snapshot {
-    // We take two snapshots of the database. The first, a
-    // `pre_snapshot_hash`, is taken of the actual database's files
-    // before taking a snapshot. The second is a the `snapshot_hash`,
-    // which is the hash of the snapshot's files. Because a database
-    // is copied (and potentially vacuumed) in order to take a
-    // snapshot, its snapshot hash might be different from that of the
-    // original database from which it was copied. If a database
-    // snapshot is taken and then doesn't change by the next snapshot,
-    // it will have the same hash as the `pre_snapshot_hash`. If a
-    // database is restored from snapshot and then doesn't change the
-    // next time snapshot is taken, it will have the same hash as the
-    // `snapshot_hash`.
-    pub pre_snapshot_hash: String,
-    pub snapshot_hash: String,
+    // A blake3 hash of the snapshot directory before compressing.
+    pub snapshot_id: String,
     pub snapshot_type: i16,
 }
 
 impl Snapshot {
     pub fn to_header_map(&self) -> Result<HashMap<String, String>, AybError> {
         let mut headers = HashMap::new();
-        headers.insert(
-            "pre_snapshot_hash".to_string(),
-            self.pre_snapshot_hash.clone(),
-        );
-        headers.insert("snapshot_hash".to_string(), self.snapshot_hash.clone());
         headers.insert(
             "snapshot_type".to_string(),
             SnapshotType::try_from(self.snapshot_type)?
@@ -76,9 +59,7 @@ impl Snapshot {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InstantiatedSnapshot {
     pub last_modified_at: DateTime<Utc>,
-    // See Snapshot for a defintion of the two hash fields.
-    pub pre_snapshot_hash: String,
-    pub snapshot_hash: String,
+    pub snapshot_id: String,
     pub snapshot_type: i16,
 }
 

--- a/src/server/snapshots/storage.rs
+++ b/src/server/snapshots/storage.rs
@@ -227,7 +227,7 @@ impl SnapshotStorage {
         snapshot: &Snapshot,
         snapshot_path: &PathBuf,
     ) -> Result<(), AybError> {
-        let path = self.db_path(entity_slug, database_slug, &snapshot.snapshot_hash);
+        let path = self.db_path(entity_slug, database_slug, &snapshot.snapshot_id);
         let mut input_file = File::open(snapshot_path)?;
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         io::copy(&mut input_file, &mut encoder)?;


### PR DESCRIPTION
As part of #14, this PR introduces blake3-based hashes to snapshot IDs, allowing us to avoid uploading duplicate snapshots if they are already present in S3.