### PR TITLE
Don't upload snapshot if it's already in S3, prune snapshots once list gets too long

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sqlx",
+ "time",
  "tokio",
  "tokio-cron-scheduler",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,6 +1387,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,6 +2702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,6 +3025,12 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -4110,11 +4132,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
+ "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -4122,16 +4147,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.120", features = ["raw_value"] }
 serde_repr = { version = "0.1.19" }
 sqlx = { version = "0.6.3", features = ["chrono", "postgres", "runtime-actix-native-tls", "sqlite"] }
-time = { verson = "0.3.36" }  # Remove line once Rust > 1.80 is out: https://github.com/rust-lang/rust/pull/124736
 toml = { version = "0.8.14" }
 tokio = { version = "1.38.0", features = ["macros", "process", "rt"] }
 tokio-cron-scheduler = { version = "0.10.2", features = ["signal"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.120", features = ["raw_value"] }
 serde_repr = { version = "0.1.19" }
 sqlx = { version = "0.6.3", features = ["chrono", "postgres", "runtime-actix-native-tls", "sqlite"] }
+time = { verson = "0.3.36" }  # Remove line once Rust > 1.80 is out: https://github.com/rust-lang/rust/pull/124736
 toml = { version = "0.8.14" }
 tokio = { version = "1.38.0", features = ["macros", "process", "rt"] }
 tokio-cron-scheduler = { version = "0.10.2", features = ["signal"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.120", features = ["raw_value"] }
 serde_repr = { version = "0.1.19" }
 sqlx = { version = "0.6.3", features = ["chrono", "postgres", "runtime-actix-native-tls", "sqlite"] }
+time = { version = "0.3.36" }
 toml = { version = "0.8.14" }
 tokio = { version = "1.38.0", features = ["macros", "process", "rt"] }
 tokio-cron-scheduler = { version = "0.10.2", features = ["signal"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.120", features = ["raw_value"] }
 serde_repr = { version = "0.1.19" }
 sqlx = { version = "0.6.3", features = ["chrono", "postgres", "runtime-actix-native-tls", "sqlite"] }
-time = { version = "0.3.36" }
+time = { version = "0.3.36" }  # Consider removing once another dependency updates time (https://github.com/time-rs/time/issues/681)
 toml = { version = "0.8.14" }
 tokio = { version = "1.38.0", features = ["macros", "process", "rt"] }
 tokio-cron-scheduler = { version = "0.10.2", features = ["signal"]}

--- a/src/client/cli.rs
+++ b/src/client/cli.rs
@@ -1,6 +1,7 @@
 use crate::ayb_db::models::{DBType, EntityType};
 use crate::client::config::ClientConfig;
 use crate::client::http::AybClient;
+use crate::error::AybError;
 use crate::formatting::TabularFormatter;
 use crate::http::structs::{EntityDatabasePath, ProfileLinkUpdate};
 use clap::builder::ValueParser;
@@ -479,6 +480,12 @@ pub async fn execute_client_command(matches: &ArgMatches) -> std::io::Result<()>
                         "Restored {}/{} to snapshot {}",
                         entity_database.entity, entity_database.database, snapshot_id
                     );
+                }
+                Err(AybError::SnapshotDoesNotExistError) => {
+                    println!(
+                        "Error: Snapshot {} does not exist for {}/{}",
+                        snapshot_id, entity_database.entity, entity_database.database
+                    )
                 }
                 Err(err) => {
                     println!("Error: {}", err);

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,7 @@ pub enum AybError {
     S3ExecutionError { message: String },
     S3ConnectionError { message: String },
     SnapshotError { message: String },
+    SnapshotDoesNotExistError,
     RecordNotFound { id: String, record_type: String },
     Other { message: String },
 }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -47,7 +47,7 @@ pub enum SqliteSnapshotMethod {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct AybConfigSnapshotsAutomation {
     pub interval: String, // A time interval in Go's time.ParseDuration format (e.g., "5m" means "every 5 minutes",
-    pub num_snapshots: u16,
+    pub max_snapshots: u16,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/server/snapshots/storage.rs
+++ b/src/server/snapshots/storage.rs
@@ -72,7 +72,7 @@ impl SnapshotStorage {
                 .build()
                 .map_err(|err| AybError::S3ExecutionError {
                     message: format!(
-                        "Unable to create object identifier for deletion for {}/{}/{}: {:?}",
+                        "Unable to create object identifier for deletion of {}/{}/{}: {:?}",
                         entity_slug, database_slug, snapshot_id, err
                     ),
                 })?;
@@ -104,24 +104,6 @@ impl SnapshotStorage {
                 })?;
         }
 
-        Ok(())
-    }
-
-    /// Deletes all files in this bucket for
-    /// `entity_slug/database_slug`. Currently only used in tests to
-    /// get to a predictable starting point.
-    pub async fn delete_all_snapshots(
-        &self,
-        entity_slug: &str,
-        database_slug: &str,
-    ) -> Result<(), AybError> {
-        let snapshots = self.list_snapshots(entity_slug, database_slug).await?;
-        let snapshot_ids = snapshots
-            .iter()
-            .map(|snapshot| snapshot.snapshot_id.clone())
-            .collect();
-        self.delete_snapshots(entity_slug, database_slug, &snapshot_ids)
-            .await?;
         Ok(())
     }
 

--- a/src/server/snapshots/storage.rs
+++ b/src/server/snapshots/storage.rs
@@ -122,7 +122,7 @@ impl SnapshotStorage {
             .client
             .get_object()
             .bucket(&self.bucket)
-            .key(&s3_path.clone())
+            .key(s3_path.clone())
             .send()
             .await
             .map_err(|err| {

--- a/tests/e2e_tests/snapshot_tests.rs
+++ b/tests/e2e_tests/snapshot_tests.rs
@@ -22,7 +22,7 @@ pub async fn test_snapshots(
     )?;
 
     // Remove all snapshots so our tests aren't affected by
-    // timing/snapshots of previous tsts.
+    // timing/snapshots from previous tsts.
     let storage = snapshot_storage(db_type).await?;
     storage
         .delete_snapshots(

--- a/tests/test-server-config-postgres.toml
+++ b/tests/test-server-config-postgres.toml
@@ -33,4 +33,4 @@ force_path_style = true
 
 [snapshots.automation]
 interval = "2s"
-num_snapshots = 10
+max_snapshots = 3

--- a/tests/test-server-config-sqlite.toml
+++ b/tests/test-server-config-sqlite.toml
@@ -33,4 +33,4 @@ force_path_style = true
 
 [snapshots.automation]
 interval = "2s"
-num_snapshots = 10
+max_snapshots = 3

--- a/tests/utils/ayb.rs
+++ b/tests/utils/ayb.rs
@@ -122,7 +122,6 @@ pub fn list_snapshots(
     let re = Regex::new(r"([a-f0-9]{64}),(\d{4,5}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00)").unwrap();
     let mut snapshots = Vec::new();
     for line in &mut output_lines[1..] {
-        println!("trying this line '{}'", line);
         let capture = re
             .captures(line)
             .expect("resulting line should be a snapshot record");


### PR DESCRIPTION
This PR introduces optimizations to the hash-based snapshots introduced as part of #14:
* After taking a snapshot, it lists snapshots already uploaded to S3-compatible storage
* If the `blake3` hash of the snapshot it just took already exists in the snapshot list, it doesn't upload it again
* If it does upload a new snapshot, it checks whether the number of snapshots now exceeds `config.snapshots.automation.max_snapshots`, and it does, it prunes the oldest snapshots from S3-compatible storage.
* Future work: avoid taking a snapshot and hashing it at all if the modification times of the database files don't differ from previously cached ones.