### PR TITLE
Replace gzip wtih zstd for compressing snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,6 @@ dependencies = [
  "dyn-clone",
  "env_logger",
  "fernet",
- "flate2",
  "go-parse-duration",
  "lettre",
  "predicates",
@@ -882,6 +881,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "walkdir",
+ "zstd",
 ]
 
 [[package]]
@@ -4942,29 +4942,28 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.0.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ directories = { version = "5.0" }
 dyn-clone = { version = "1.0.17" }
 env_logger = { version = "0.10.2" }
 fernet = { version = "0.2.2" }
-flate2 = { version = "1.0.30" }
 go-parse-duration = { version = "0.1.1" }
 lettre = { version = "0.11.7", features = ["tokio1-native-tls"] }
 quoted_printable = { version = "0.5.0" }
@@ -50,6 +49,7 @@ url = { version = "2.5.2", features = ["serde"] }
 urlencoding = { version = "2.1.3" }
 uuid = { version = "1.10.0", features = ["v7"] }
 walkdir = { version = "2.5.0" }
+zstd = { version = "0.13.2" }
 
 [dev-dependencies]
 assert_cmd = "2.0"


### PR DESCRIPTION
* zstd [appears to provide](https://facebook.github.io/zstd/) a better compression ratio than gzip/zlib while at the same time compressing/decompressing faster.
* In microbenchmarks on tiny SQLite files, I saw tiny improvements to compression, though no throughput improvement. Presumably compression/decompression throughput differences are more readily apparent for larger files.
* Nonetheless, the change is simple enough to warrant implementing.