### PR TITLE
Migrations for sharing permissions data models

### DIFF
--- a/migrations/postgres/2024083101_permission.sql
+++ b/migrations/postgres/2024083101_permission.sql
@@ -1,0 +1,11 @@
+CREATE TABLE entity_database_permission (
+       entity_id INT NOT NULL,
+       database_id INT NOT NULL,       
+       sharing_level SMALLINT NOT NULL,
+
+       FOREIGN KEY(entity_id) REFERENCES entity(id),
+       FOREIGN KEY(database_id) REFERENCES database(id)
+       UNIQUE(entity_id, database_id)
+);
+
+ALTER TABLE database ADD public_sharing_level SMALLINT NOT NULL DEFAULT 0; -- defaults to no public access

--- a/migrations/postgres/2024083101_permission.sql
+++ b/migrations/postgres/2024083101_permission.sql
@@ -4,7 +4,7 @@ CREATE TABLE entity_database_permission (
        sharing_level SMALLINT NOT NULL,
 
        FOREIGN KEY(entity_id) REFERENCES entity(id),
-       FOREIGN KEY(database_id) REFERENCES database(id)
+       FOREIGN KEY(database_id) REFERENCES database(id),
        UNIQUE(entity_id, database_id)
 );
 

--- a/migrations/sqlite/2024083101_permission.sql
+++ b/migrations/sqlite/2024083101_permission.sql
@@ -1,0 +1,11 @@
+CREATE TABLE entity_database_permission (
+       entity_id INT NOT NULL,
+       database_id INT NOT NULL,       
+       sharing_level SMALLINT NOT NULL,
+
+       FOREIGN KEY(entity_id) REFERENCES entity(id),
+       FOREIGN KEY(database_id) REFERENCES database(id)
+       UNIQUE(entity_id, database_id)
+);
+
+ALTER TABLE database ADD public_sharing_level SMALLINT NOT NULL DEFAULT 0; -- defaults to no public access

--- a/migrations/sqlite/2024083101_permission.sql
+++ b/migrations/sqlite/2024083101_permission.sql
@@ -4,7 +4,7 @@ CREATE TABLE entity_database_permission (
        sharing_level SMALLINT NOT NULL,
 
        FOREIGN KEY(entity_id) REFERENCES entity(id),
-       FOREIGN KEY(database_id) REFERENCES database(id)
+       FOREIGN KEY(database_id) REFERENCES database(id),
        UNIQUE(entity_id, database_id)
 );
 


### PR DESCRIPTION
Introduce migrations for the entity/database permissions and public sharing permissions data models. Part of #281.