### PR TITLE
Introduce update_database endpoint to enable public sharing level update

### DIFF
--- a/src/ayb_db/models.rs
+++ b/src/ayb_db/models.rs
@@ -167,6 +167,12 @@ pub struct InstantiatedDatabase {
     pub public_sharing_level: i16,
 }
 
+/// Represents properties of a database that can be updated.
+#[derive(Debug)]
+pub struct PartialDatabase {
+    pub public_sharing_level: Option<i16>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Entity {
     pub slug: String,

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -266,4 +266,28 @@ impl AybClient {
         self.handle_empty_response(response, reqwest::StatusCode::OK)
             .await
     }
+
+    pub async fn update_database(
+        &self,
+        entity: &str,
+        database: &str,
+        public_sharing_level: &PublicSharingLevel,
+    ) -> Result<(), AybError> {
+        let mut headers = HeaderMap::new();
+        self.add_bearer_token(&mut headers)?;
+
+        headers.insert(
+            HeaderName::from_static("public-sharing-level"),
+            HeaderValue::from_str(public_sharing_level.to_str()).unwrap(),
+        );
+
+        let response = reqwest::Client::new()
+            .patch(self.make_url(format!("{}/{}/update", entity, database)))
+            .headers(headers)
+            .send()
+            .await?;
+
+        self.handle_empty_response(response, reqwest::StatusCode::OK)
+            .await
+    }
 }

--- a/src/server/endpoints/confirm.rs
+++ b/src/server/endpoints/confirm.rs
@@ -7,7 +7,7 @@ use crate::error::AybError;
 use crate::http::structs::APIToken as APIAPIToken;
 use crate::server::config::AybConfig;
 use crate::server::tokens::{decrypt_auth_token, generate_api_token};
-use crate::server::utils::get_header;
+use crate::server::utils::get_required_header;
 use actix_web::{post, web, HttpRequest, HttpResponse};
 
 #[post("/v1/confirm")]
@@ -16,7 +16,7 @@ async fn confirm(
     ayb_db: web::Data<Box<dyn AybDb>>,
     ayb_config: web::Data<AybConfig>,
 ) -> Result<HttpResponse, AybError> {
-    let auth_token = get_header(&req, "authentication-token")?;
+    let auth_token = get_required_header(&req, "authentication-token")?;
     let auth_details = decrypt_auth_token(auth_token, &ayb_config.authentication)?;
 
     let created_entity = ayb_db

--- a/src/server/endpoints/create_database.rs
+++ b/src/server/endpoints/create_database.rs
@@ -10,7 +10,7 @@ use crate::hosted_db::paths::{
 use crate::http::structs::{Database as APIDatabase, EntityDatabasePath};
 use crate::server::config::AybConfig;
 use crate::server::permissions::can_create_database;
-use crate::server::utils::{get_header, unwrap_authenticated_entity};
+use crate::server::utils::{get_required_header, unwrap_authenticated_entity};
 use actix_web::{post, web, HttpRequest, HttpResponse};
 
 #[post("/v1/{entity}/{database}/create")]
@@ -23,8 +23,8 @@ async fn create_database(
 ) -> Result<HttpResponse, AybError> {
     let entity_slug = &path.entity;
     let entity = ayb_db.get_entity_by_slug(entity_slug).await?;
-    let db_type = get_header(&req, "db-type")?;
-    let public_sharing_level = get_header(&req, "public-sharing-level")?;
+    let db_type = get_required_header(&req, "db-type")?;
+    let public_sharing_level = get_required_header(&req, "public-sharing-level")?;
     let database = Database {
         entity_id: entity.id,
         slug: path.database.clone(),

--- a/src/server/endpoints/create_database.rs
+++ b/src/server/endpoints/create_database.rs
@@ -42,7 +42,7 @@ async fn create_database(
     } else {
         Err(AybError::Other {
             message: format!(
-                "Authenticated entity {} can not create a database for entity {}",
+                "Authenticated entity {} can't create a database for entity {}",
                 authenticated_entity.slug, entity_slug
             ),
         })

--- a/src/server/endpoints/list_snapshots.rs
+++ b/src/server/endpoints/list_snapshots.rs
@@ -36,7 +36,7 @@ async fn list_snapshots(
     } else {
         Err(AybError::Other {
             message: format!(
-                "Authenticated entity {} can not manage snapshots on database {}/{}",
+                "Authenticated entity {} can't manage snapshots on database {}/{}",
                 authenticated_entity.slug, entity_slug, database_slug
             ),
         })

--- a/src/server/endpoints/mod.rs
+++ b/src/server/endpoints/mod.rs
@@ -6,6 +6,7 @@ mod log_in;
 mod query;
 mod register;
 mod restore_snapshot;
+mod update_database;
 mod update_profile;
 
 pub use confirm::confirm as confirm_endpoint;
@@ -16,4 +17,5 @@ pub use log_in::log_in as log_in_endpoint;
 pub use query::query as query_endpoint;
 pub use register::register as register_endpoint;
 pub use restore_snapshot::restore_snapshot as restore_snapshot_endpoint;
+pub use update_database::update_database as update_db_endpoint;
 pub use update_profile::update_profile as update_profile_endpoint;

--- a/src/server/endpoints/query.rs
+++ b/src/server/endpoints/query.rs
@@ -31,7 +31,7 @@ async fn query(
     } else {
         Err(AybError::Other {
             message: format!(
-                "Authenticated entity {} can not query database {}/{}",
+                "Authenticated entity {} can't query database {}/{}",
                 authenticated_entity.slug, entity_slug, database_slug
             ),
         })

--- a/src/server/endpoints/register.rs
+++ b/src/server/endpoints/register.rs
@@ -5,7 +5,7 @@ use crate::error::AybError;
 use crate::http::structs::{AuthenticationDetails, EmptyResponse};
 use crate::server::config::AybConfig;
 use crate::server::tokens::encrypt_auth_token;
-use crate::server::utils::{get_header, get_lowercased_header};
+use crate::server::utils::{get_lowercased_header, get_required_header};
 use crate::server::web_frontend::WebFrontendDetails;
 use actix_web::{post, web, HttpRequest, HttpResponse};
 use std::str::FromStr;
@@ -19,7 +19,7 @@ async fn register(
 ) -> Result<HttpResponse, AybError> {
     let entity = get_lowercased_header(&req, "entity")?;
     let email_address = get_lowercased_header(&req, "email-address")?;
-    let entity_type = get_header(&req, "entity-type")?;
+    let entity_type = get_required_header(&req, "entity-type")?;
     let desired_entity = ayb_db.get_entity_by_slug(&entity).await;
     // Ensure that there are no authentication methods aside from
     // perhaps the currently requested one.

--- a/src/server/endpoints/restore_snapshot.rs
+++ b/src/server/endpoints/restore_snapshot.rs
@@ -42,7 +42,7 @@ async fn restore_snapshot(
     } else {
         Err(AybError::Other {
             message: format!(
-                "Authenticated entity {} can not manage snapshots on database {}/{}",
+                "Authenticated entity {} can't manage snapshots on database {}/{}",
                 authenticated_entity.slug, entity_slug, database_slug
             ),
         })

--- a/src/server/endpoints/update_database.rs
+++ b/src/server/endpoints/update_database.rs
@@ -35,7 +35,7 @@ async fn update_database(
     } else {
         Err(AybError::Other {
             message: format!(
-                "Authenticated entity {} can not update database {}/{}",
+                "Authenticated entity {} can't update database {}/{}",
                 authenticated_entity.slug, entity_slug, database_slug
             ),
         })

--- a/src/server/endpoints/update_database.rs
+++ b/src/server/endpoints/update_database.rs
@@ -1,0 +1,43 @@
+use crate::ayb_db::db_interfaces::AybDb;
+use crate::ayb_db::models::{InstantiatedEntity, PartialDatabase, PublicSharingLevel};
+use std::str::FromStr;
+
+use crate::error::AybError;
+use crate::http::structs::{EmptyResponse, EntityDatabasePath};
+use crate::server::permissions::can_manage_database;
+use crate::server::utils::{get_optional_header, unwrap_authenticated_entity};
+use actix_web::{patch, web, HttpRequest, HttpResponse};
+
+#[patch("/v1/{entity}/{database}/update")]
+async fn update_database(
+    path: web::Path<EntityDatabasePath>,
+    req: HttpRequest,
+    ayb_db: web::Data<Box<dyn AybDb>>,
+    authenticated_entity: Option<web::ReqData<InstantiatedEntity>>,
+) -> Result<HttpResponse, AybError> {
+    let entity_slug = &path.entity.to_lowercase();
+    let database_slug = &path.database;
+    let database = ayb_db.get_database(entity_slug, database_slug).await?;
+    let authenticated_entity = unwrap_authenticated_entity(&authenticated_entity)?;
+    if can_manage_database(&authenticated_entity, &database) {
+        let public_sharing_level = get_optional_header(&req, "public-sharing-level")?;
+        let mut partial_database = PartialDatabase {
+            public_sharing_level: None,
+        };
+        if public_sharing_level.is_some() {
+            partial_database.public_sharing_level =
+                Some(PublicSharingLevel::from_str(&public_sharing_level.unwrap())? as i16);
+        }
+        ayb_db
+            .update_database_by_id(database.id, &partial_database)
+            .await?;
+        Ok(HttpResponse::Ok().json(EmptyResponse {}))
+    } else {
+        Err(AybError::Other {
+            message: format!(
+                "Authenticated entity {} can not update database {}/{}",
+                authenticated_entity.slug, entity_slug, database_slug
+            ),
+        })
+    }
+}

--- a/src/server/endpoints/update_profile.rs
+++ b/src/server/endpoints/update_profile.rs
@@ -82,7 +82,7 @@ pub async fn update_profile(
     partial.links = links;
 
     ayb_db
-        .update_entity_by_id(&partial, authenticated_entity.id)
+        .update_entity_by_id(authenticated_entity.id, &partial)
         .await?;
 
     Ok(HttpResponse::Ok().json(EmptyResponse {}))

--- a/src/server/permissions.rs
+++ b/src/server/permissions.rs
@@ -8,6 +8,14 @@ pub fn can_create_database(
     authenticated_entity.id == desired_entity.id
 }
 
+pub fn can_manage_database(
+    authenticated_entity: &InstantiatedEntity,
+    database: &InstantiatedDatabase,
+) -> bool {
+    // An entity/user can only manage its own databases (for now)
+    authenticated_entity.id == database.entity_id
+}
+
 pub fn can_query(
     authenticated_entity: &InstantiatedEntity,
     database: &InstantiatedDatabase,

--- a/src/server/server_runner.rs
+++ b/src/server/server_runner.rs
@@ -6,7 +6,7 @@ use crate::server::config::AybConfigCors;
 use crate::server::endpoints::{
     confirm_endpoint, create_db_endpoint, entity_details_endpoint, list_snapshots_endpoint,
     log_in_endpoint, query_endpoint, register_endpoint, restore_snapshot_endpoint,
-    update_profile_endpoint,
+    update_db_endpoint, update_profile_endpoint,
 };
 use crate::server::snapshots::execution::schedule_periodic_snapshots;
 use crate::server::tokens::retrieve_and_validate_api_token;
@@ -28,6 +28,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         web::scope("")
             .wrap(HttpAuthentication::bearer(entity_validator))
             .service(create_db_endpoint)
+            .service(update_db_endpoint)
             .service(query_endpoint)
             .service(entity_details_endpoint)
             .service(update_profile_endpoint)

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4,7 +4,8 @@ mod e2e_tests;
 mod utils;
 
 use crate::e2e_tests::{
-    test_create_and_query_db, test_entity_details_and_profile, test_registration, test_snapshots,
+    test_create_and_query_db, test_entity_details_and_profile, test_permissions, test_registration,
+    test_snapshots,
 };
 use crate::utils::testing::{AybServer, Cleanup, SmtpServer};
 use assert_cmd::prelude::*;
@@ -81,6 +82,7 @@ async fn client_server_integration(
     test_create_and_query_db(&config_path, &api_keys, server_url, &mut expected_config)?;
     test_entity_details_and_profile(&config_path, &api_keys)?;
     test_snapshots(db_type, &config_path, &api_keys).await?;
+    test_permissions(&config_path, &api_keys).await?;
 
     Ok(())
 }

--- a/tests/e2e_tests/create_and_query_db_tests.rs
+++ b/tests/e2e_tests/create_and_query_db_tests.rs
@@ -14,7 +14,7 @@ pub fn test_create_and_query_db(
     create_database(
         &config_path,
         &api_keys.get("second").unwrap()[0],
-        "Error: Authenticated entity e2e-second can not create a database for entity e2e-first",
+        "Error: Authenticated entity e2e-second can't create a database for entity e2e-first",
     )?;
 
     // Can't create database on e2e-first with invalid token.
@@ -45,7 +45,7 @@ pub fn test_create_and_query_db(
         "CREATE TABLE test_table(fname varchar, lname varchar);",
         FIRST_ENTITY_DB,
         "table",
-        "Error: Authenticated entity e2e-second can not query database e2e-first/test.sqlite",
+        "Error: Authenticated entity e2e-second can't query database e2e-first/test.sqlite",
     )?;
 
     // Can't query database with bad API key.

--- a/tests/e2e_tests/mod.rs
+++ b/tests/e2e_tests/mod.rs
@@ -1,10 +1,12 @@
 mod create_and_query_db_tests;
 mod entity_details_and_profile_tests;
+mod permissions_tests;
 mod registration_tests;
 mod snapshot_tests;
 
 pub use create_and_query_db_tests::test_create_and_query_db;
 pub use entity_details_and_profile_tests::test_entity_details_and_profile;
+pub use permissions_tests::test_permissions;
 pub use registration_tests::test_registration;
 pub use snapshot_tests::test_snapshots;
 

--- a/tests/e2e_tests/permissions_tests.rs
+++ b/tests/e2e_tests/permissions_tests.rs
@@ -22,7 +22,7 @@ pub async fn test_permissions(
         "SELECT COUNT(*) AS the_count FROM test_table;",
         FIRST_ENTITY_DB,
         "table",
-        "Error: Authenticated entity e2e-second can not query database e2e-first/test.sqlite",
+        "Error: Authenticated entity e2e-second can't query database e2e-first/test.sqlite",
     )?;
 
     //TODO(marcua): Implement "can't find database in list" part.
@@ -34,7 +34,7 @@ pub async fn test_permissions(
         &api_keys.get("second").unwrap()[0],
         FIRST_ENTITY_DB,
         "metadata",
-        "Error: Authenticated entity e2e-second can not update database e2e-first/test.sqlite",
+        "Error: Authenticated entity e2e-second can't update database e2e-first/test.sqlite",
     )?;
 
     update_database(

--- a/tests/e2e_tests/permissions_tests.rs
+++ b/tests/e2e_tests/permissions_tests.rs
@@ -1,0 +1,76 @@
+use crate::e2e_tests::FIRST_ENTITY_DB;
+use crate::utils::ayb::{query, update_database};
+use std::collections::HashMap;
+
+pub async fn test_permissions(
+    config_path: &str,
+    api_keys: &HashMap<String, Vec<String>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // While first entity has access to database (it's the owner), the
+    // second one can't query or find it in list.
+    query(
+        &config_path,
+        &api_keys.get("first").unwrap()[1],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        " the_count \n-----------\n 3 \n\nRows: 1",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Authenticated entity e2e-second can not query database e2e-first/test.sqlite",
+    )?;
+
+    //TODO(marcua): Implement "can't find database in list" part.
+
+    // Add metadata-only access, ensure you can list but not query
+    // Second entity can't update database, but first can.
+    update_database(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "metadata",
+        "Error: Authenticated entity e2e-second can not update database e2e-first/test.sqlite",
+    )?;
+
+    update_database(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "metadata",
+        "Database e2e-first/test.sqlite updated successfully",
+    )?;
+
+    // TODO(marcua): Implement list, no query checks
+
+    // TODO(marcua): When we support forking, add forking tests.
+
+    // Add public read-only permissions, ensure entity can select but not insert
+    update_database(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "read-only",
+        "Database e2e-first/test.sqlite updated successfully",
+    )?;
+
+    // TODO(marcua): Implement list and query checks
+
+    // Remove permissions, ensure entity can't query or find database in list
+    update_database(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "no-access",
+        "Database e2e-first/test.sqlite updated successfully",
+    )?;
+
+    // TODO(marcua): Implement no list and no query checks
+
+    // TODO(marcua): When ready, test entity-database permissions.
+    Ok(())
+}

--- a/tests/e2e_tests/snapshot_tests.rs
+++ b/tests/e2e_tests/snapshot_tests.rs
@@ -18,7 +18,7 @@ pub async fn test_snapshots(
         &api_keys.get("second").unwrap()[0],
         FIRST_ENTITY_DB,
         "csv",
-        "Error: Authenticated entity e2e-second can not manage snapshots on database e2e-first/test.sqlite",
+        "Error: Authenticated entity e2e-second can't manage snapshots on database e2e-first/test.sqlite",
     )?;
 
     // Remove all snapshots so our tests aren't affected by

--- a/tests/utils/ayb.rs
+++ b/tests/utils/ayb.rs
@@ -228,3 +228,18 @@ pub fn update_profile(
     cmd.assert().success().stdout(format!("{}\n", result));
     Ok(())
 }
+
+pub fn update_database(
+    config: &str,
+    api_key: &str,
+    database: &str,
+    public_sharing_level: &str,
+    result: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cmd = ayb_assert_cmd!("client", "--config", config, "update_database", database, "--public_sharing_level", public_sharing_level; {
+        "AYB_API_TOKEN" => api_key,
+    });
+
+    cmd.stdout(format!("{}\n", result));
+    Ok(())
+}


### PR DESCRIPTION
This PR introduces an `update_database` endpoint and client support for updating properties on a database. The one property currently supported is `public_sharing_level`, which controls what level of access the public has to a database. Also included are e2e tests that test whether public sharing level updates are possible. Future PRs will make use of and enforce these permissions. 