### PR TITLE
Permissions public_sharing_level read-only/fork support

### DIFF
--- a/src/ayb_db/models.rs
+++ b/src/ayb_db/models.rs
@@ -120,30 +120,26 @@ impl AuthenticationMethodStatus {
 #[repr(i16)]
 pub enum PublicSharingLevel {
     NoAccess = 0,
-    Metadata = 1,
-    Fork = 2,
-    ReadOnly = 3,
+    Fork = 1,
+    ReadOnly = 2,
 }
 
 from_str!(PublicSharingLevel, {
     "no-access" => PublicSharingLevel::NoAccess,
-    "metadata" => PublicSharingLevel::Metadata,
     "fork" => PublicSharingLevel::Fork,
     "read-only" => PublicSharingLevel::ReadOnly
 });
 
 try_from_i16!(PublicSharingLevel, {
     0 => PublicSharingLevel::NoAccess,
-    1 => PublicSharingLevel::Metadata,
-    2 => PublicSharingLevel::Fork,
-    3 => PublicSharingLevel::ReadOnly
+    1 => PublicSharingLevel::Fork,
+    2 => PublicSharingLevel::ReadOnly
 });
 
 impl PublicSharingLevel {
     pub fn to_str(&self) -> &str {
         match self {
             PublicSharingLevel::NoAccess => "no-access",
-            PublicSharingLevel::Metadata => "metadata",
             PublicSharingLevel::Fork => "fork",
             PublicSharingLevel::ReadOnly => "read-only",
         }

--- a/src/bin/ayb_isolated_runner.rs
+++ b/src/bin/ayb_isolated_runner.rs
@@ -22,9 +22,15 @@ fn main() -> Result<(), serde_json::Error> {
     .expect("query mode should be 0 or 1");
     let query = (args[3..]).to_vec();
     let result = query_sqlite(&PathBuf::from(db_file), &query.join(" "), false, query_mode);
+    let query_mode2 = QueryMode::try_from(
+        args[2]
+            .parse::<i16>()
+            .expect("query mode should be an integer"),
+    )
+    .expect("query mode should be 0 or 1");
     match result {
         Ok(result) => println!("{}", serde_json::to_string(&result)?),
-        Err(error) => eprintln!("{}", serde_json::to_string(&error)?),
+        Err(error) => eprintln!("{}---{}---{:?}---{:?}", serde_json::to_string(&error)?, db_file, query_mode2, query),
     }
     Ok(())
 }

--- a/src/bin/ayb_isolated_runner.rs
+++ b/src/bin/ayb_isolated_runner.rs
@@ -22,21 +22,9 @@ fn main() -> Result<(), serde_json::Error> {
     .expect("query mode should be 0 or 1");
     let query = (args[3..]).to_vec();
     let result = query_sqlite(&PathBuf::from(db_file), &query.join(" "), false, query_mode);
-    let query_mode2 = QueryMode::try_from(
-        args[2]
-            .parse::<i16>()
-            .expect("query mode should be an integer"),
-    )
-    .expect("query mode should be 0 or 1");
     match result {
         Ok(result) => println!("{}", serde_json::to_string(&result)?),
-        Err(error) => eprintln!(
-            "{}---{}---{:?}---{:?}",
-            serde_json::to_string(&error)?,
-            db_file,
-            query_mode2,
-            query
-        ),
+        Err(error) => eprintln!("{}", serde_json::to_string(&error)?),
     }
     Ok(())
 }

--- a/src/bin/ayb_isolated_runner.rs
+++ b/src/bin/ayb_isolated_runner.rs
@@ -1,10 +1,11 @@
 use ayb::hosted_db::sqlite::query_sqlite;
+use ayb::hosted_db::QueryMode;
 use std::env;
 use std::path::PathBuf;
 
 /// This binary runs a query against a database and returns the
 /// result in QueryResults format. To run it, you would type:
-/// $ ayb_isolated_runner database.sqlite SELECT xyz FROM ...
+/// $ ayb_isolated_runner database.sqlite [0=read-only|1=read-write] SELECT xyz FROM ...
 ///
 /// This command is meant to be run inside a sandbox that isolates
 /// parallel invocations of the command from accessing each
@@ -13,8 +14,14 @@ use std::path::PathBuf;
 fn main() -> Result<(), serde_json::Error> {
     let args: Vec<String> = env::args().collect();
     let db_file = &args[1];
+    let query_mode = QueryMode::try_from(
+        args[2]
+            .parse::<i16>()
+            .expect("query mode should be an integer"),
+    )
+    .expect("query mode should be 0 or 1");
     let query = (args[2..]).to_vec();
-    let result = query_sqlite(&PathBuf::from(db_file), &query.join(" "), false);
+    let result = query_sqlite(&PathBuf::from(db_file), &query.join(" "), false, query_mode);
     match result {
         Ok(result) => println!("{}", serde_json::to_string(&result)?),
         Err(error) => eprintln!("{}", serde_json::to_string(&error)?),

--- a/src/bin/ayb_isolated_runner.rs
+++ b/src/bin/ayb_isolated_runner.rs
@@ -30,7 +30,13 @@ fn main() -> Result<(), serde_json::Error> {
     .expect("query mode should be 0 or 1");
     match result {
         Ok(result) => println!("{}", serde_json::to_string(&result)?),
-        Err(error) => eprintln!("{}---{}---{:?}---{:?}", serde_json::to_string(&error)?, db_file, query_mode2, query),
+        Err(error) => eprintln!(
+            "{}---{}---{:?}---{:?}",
+            serde_json::to_string(&error)?,
+            db_file,
+            query_mode2,
+            query
+        ),
     }
     Ok(())
 }

--- a/src/bin/ayb_isolated_runner.rs
+++ b/src/bin/ayb_isolated_runner.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), serde_json::Error> {
             .expect("query mode should be an integer"),
     )
     .expect("query mode should be 0 or 1");
-    let query = (args[2..]).to_vec();
+    let query = (args[3..]).to_vec();
     let result = query_sqlite(&PathBuf::from(db_file), &query.join(" "), false, query_mode);
     match result {
         Ok(result) => println!("{}", serde_json::to_string(&result)?),

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,7 @@ use url;
 #[serde(tag = "type")]
 pub enum AybError {
     DurationParseError { message: String },
+    NoWriteAccessError { message: String },
     S3ExecutionError { message: String },
     S3ConnectionError { message: String },
     SnapshotError { message: String },
@@ -31,6 +32,7 @@ impl Display for AybError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             AybError::Other { message } => write!(f, "{}", message),
+            AybError::NoWriteAccessError { message } => write!(f, "{}", message),
             _ => write!(f, "{:?}", self),
         }
     }

--- a/src/hosted_db.rs
+++ b/src/hosted_db.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::vec::Vec;
 
+#[derive(Debug)]
 #[repr(i16)]
 pub enum QueryMode {
     ReadOnly = 0,

--- a/src/hosted_db/sandbox.rs
+++ b/src/hosted_db/sandbox.rs
@@ -99,7 +99,6 @@ pub async fn run_in_sandbox(
         .arg(tmp_db_path)
         .arg((query_mode as i16).to_string())
         .arg(query);
-    println!("The commmand {:?}", cmd);
 
     let mut child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
 

--- a/src/hosted_db/sandbox.rs
+++ b/src/hosted_db/sandbox.rs
@@ -94,16 +94,14 @@ pub async fn run_in_sandbox(
             isolated_runner_path.display()
         ),
     ]);
-
-    let mut child = cmd
-        .arg("--")
+    cmd.arg("--")
         .arg("/tmp/ayb_isolated_runner")
         .arg(tmp_db_path)
         .arg((query_mode as i16).to_string())
-        .arg(query)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
+        .arg(query);
+    println!("The commmand {:?}", cmd);
+
+    let mut child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
 
     let mut stdout_reader = BufReader::new(child.stdout.take().unwrap());
     let mut stderr_reader = BufReader::new(child.stderr.take().unwrap());

--- a/src/hosted_db/sandbox.rs
+++ b/src/hosted_db/sandbox.rs
@@ -28,6 +28,7 @@ SOFTWARE.
 
 use crate::error::AybError;
 use crate::hosted_db::paths::{pathbuf_to_file_name, pathbuf_to_parent};
+use crate::hosted_db::QueryMode;
 use serde::{Deserialize, Serialize};
 use std::env::current_exe;
 use std::fs::canonicalize;
@@ -51,6 +52,7 @@ pub async fn run_in_sandbox(
     nsjail: &Path,
     db_path: &PathBuf,
     query: &str,
+    query_mode: QueryMode,
 ) -> Result<RunResult, AybError> {
     let mut cmd = tokio::process::Command::new(nsjail);
 
@@ -97,6 +99,7 @@ pub async fn run_in_sandbox(
         .arg("--")
         .arg("/tmp/ayb_isolated_runner")
         .arg(tmp_db_path)
+        .arg((query_mode as i16).to_string())
         .arg(query)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src/hosted_db/sqlite.rs
+++ b/src/hosted_db/sqlite.rs
@@ -87,7 +87,8 @@ pub async fn potentially_isolated_sqlite_query(
     query_mode: QueryMode,
 ) -> Result<QueryResult, AybError> {
     if let Some(isolation) = isolation {
-        let result = run_in_sandbox(Path::new(&isolation.nsjail_path), path, query).await?;
+        let result =
+            run_in_sandbox(Path::new(&isolation.nsjail_path), path, query, query_mode).await?;
 
         if !result.stderr.is_empty() {
             let error: AybError = serde_json::from_str(&result.stderr)?;

--- a/src/hosted_db/sqlite.rs
+++ b/src/hosted_db/sqlite.rs
@@ -90,7 +90,6 @@ pub async fn potentially_isolated_sqlite_query(
         let result =
             run_in_sandbox(Path::new(&isolation.nsjail_path), path, query, query_mode).await?;
 
-        println!("Results {:?}", result);
         if !result.stderr.is_empty() {
             let error: AybError = serde_json::from_str(&result.stderr)?;
             return Err(error);

--- a/src/hosted_db/sqlite.rs
+++ b/src/hosted_db/sqlite.rs
@@ -52,7 +52,7 @@ pub fn query_sqlite(
             if code.code == rusqlite::ErrorCode::ReadOnly && code.extended_code == 8 =>
         {
             AybError::NoWriteAccessError {
-                message: "Attempted to write to a read-only database".to_string(),
+                message: "Attempted to write to database while in read-only mode".to_string(),
             }
         }
         _ => AybError::from(err),

--- a/src/hosted_db/sqlite.rs
+++ b/src/hosted_db/sqlite.rs
@@ -90,6 +90,7 @@ pub async fn potentially_isolated_sqlite_query(
         let result =
             run_in_sandbox(Path::new(&isolation.nsjail_path), path, query, query_mode).await?;
 
+        println!("Results {:?}", result);
         if !result.stderr.is_empty() {
             let error: AybError = serde_json::from_str(&result.stderr)?;
             return Err(error);

--- a/src/server/endpoints/query.rs
+++ b/src/server/endpoints/query.rs
@@ -3,10 +3,10 @@ use crate::ayb_db::models::{DBType, InstantiatedEntity};
 
 use crate::error::AybError;
 use crate::hosted_db::paths::current_database_path;
-use crate::hosted_db::{run_query, QueryMode, QueryResult};
+use crate::hosted_db::{run_query, QueryResult};
 use crate::http::structs::EntityDatabasePath;
 use crate::server::config::AybConfig;
-use crate::server::permissions::can_query;
+use crate::server::permissions::highest_query_access_level;
 use crate::server::utils::unwrap_authenticated_entity;
 use actix_web::{post, web};
 
@@ -23,25 +23,26 @@ async fn query(
     let database = ayb_db.get_database(entity_slug, database_slug).await?;
     let authenticated_entity = unwrap_authenticated_entity(&authenticated_entity)?;
 
-    if can_query(&authenticated_entity, &database) {
-        let db_type = DBType::try_from(database.db_type)?;
-        let db_path = current_database_path(entity_slug, database_slug, &ayb_config.data_path)?;
-        // TODO(marcua): Determine read-only or read-write
-        let result = run_query(
-            &db_path,
-            &query,
-            &db_type,
-            &ayb_config.isolation,
-            QueryMode::ReadWrite,
-        )
-        .await?;
-        Ok(web::Json(result))
-    } else {
-        Err(AybError::Other {
+    let access_level = highest_query_access_level(&authenticated_entity, &database)?;
+    match access_level {
+        Some(access_level) => {
+              let db_type = DBType::try_from(database.db_type)?;
+            let db_path = current_database_path(entity_slug, database_slug, &ayb_config.data_path)?;
+            let result = run_query(
+                &db_path,
+                &query,
+                &db_type,
+                &ayb_config.isolation,
+                access_level,
+            )
+            .await?;
+            Ok(web::Json(result))
+        }
+        None => Err(AybError::Other {
             message: format!(
                 "Authenticated entity {} can't query database {}/{}",
                 authenticated_entity.slug, entity_slug, database_slug
             ),
-        })
+        }),
     }
 }

--- a/src/server/endpoints/query.rs
+++ b/src/server/endpoints/query.rs
@@ -3,7 +3,7 @@ use crate::ayb_db::models::{DBType, InstantiatedEntity};
 
 use crate::error::AybError;
 use crate::hosted_db::paths::current_database_path;
-use crate::hosted_db::{run_query, QueryResult};
+use crate::hosted_db::{run_query, QueryMode, QueryResult};
 use crate::http::structs::EntityDatabasePath;
 use crate::server::config::AybConfig;
 use crate::server::permissions::can_query;
@@ -26,7 +26,15 @@ async fn query(
     if can_query(&authenticated_entity, &database) {
         let db_type = DBType::try_from(database.db_type)?;
         let db_path = current_database_path(entity_slug, database_slug, &ayb_config.data_path)?;
-        let result = run_query(&db_path, &query, &db_type, &ayb_config.isolation).await?;
+        // TODO(marcua): Determine read-only or read-write
+        let result = run_query(
+            &db_path,
+            &query,
+            &db_type,
+            &ayb_config.isolation,
+            QueryMode::ReadWrite,
+        )
+        .await?;
         Ok(web::Json(result))
     } else {
         Err(AybError::Other {

--- a/src/server/endpoints/query.rs
+++ b/src/server/endpoints/query.rs
@@ -26,7 +26,7 @@ async fn query(
     let access_level = highest_query_access_level(&authenticated_entity, &database)?;
     match access_level {
         Some(access_level) => {
-              let db_type = DBType::try_from(database.db_type)?;
+            let db_type = DBType::try_from(database.db_type)?;
             let db_path = current_database_path(entity_slug, database_slug, &ayb_config.data_path)?;
             let result = run_query(
                 &db_path,

--- a/src/server/permissions.rs
+++ b/src/server/permissions.rs
@@ -1,4 +1,10 @@
-use crate::ayb_db::models::{InstantiatedDatabase, InstantiatedEntity};
+use crate::ayb_db::models::{InstantiatedDatabase, InstantiatedEntity, PublicSharingLevel};
+use crate::error::AybError;
+use crate::hosted_db::QueryMode;
+
+fn is_owner(authenticated_entity: &InstantiatedEntity, database: &InstantiatedDatabase) -> bool {
+    authenticated_entity.id == database.entity_id
+}
 
 pub fn can_create_database(
     authenticated_entity: &InstantiatedEntity,
@@ -8,20 +14,37 @@ pub fn can_create_database(
     authenticated_entity.id == desired_entity.id
 }
 
+pub fn can_discover_database(
+    authenticated_entity: &InstantiatedEntity,
+    database: &InstantiatedDatabase,
+) -> Result<bool, AybError> {
+    let public_sharing_level = PublicSharingLevel::try_from(database.public_sharing_level)?;
+    Ok(is_owner(authenticated_entity, database)
+        || public_sharing_level == PublicSharingLevel::ReadOnly
+        || public_sharing_level == PublicSharingLevel::Fork)
+}
+
 pub fn can_manage_database(
     authenticated_entity: &InstantiatedEntity,
     database: &InstantiatedDatabase,
 ) -> bool {
     // An entity/user can only manage its own databases (for now)
-    authenticated_entity.id == database.entity_id
+    is_owner(authenticated_entity, database)
 }
 
-pub fn can_query(
+pub fn highest_query_access_level(
     authenticated_entity: &InstantiatedEntity,
     database: &InstantiatedDatabase,
-) -> bool {
-    // An entity/user can only query its own databases (for now)
-    authenticated_entity.id == database.entity_id
+) -> Result<Option<QueryMode>, AybError> {
+    if is_owner(authenticated_entity, database) {
+        Ok(Some(QueryMode::ReadWrite))
+    } else if PublicSharingLevel::try_from(database.public_sharing_level)?
+        == PublicSharingLevel::ReadOnly
+    {
+        Ok(Some(QueryMode::ReadOnly))
+    } else {
+        Ok(None)
+    }
 }
 
 pub fn can_manage_snapshots(
@@ -29,5 +52,5 @@ pub fn can_manage_snapshots(
     database: &InstantiatedDatabase,
 ) -> bool {
     // An entity/user can only manage snapshots on its own databases (for now)
-    authenticated_entity.id == database.entity_id
+    is_owner(authenticated_entity, database)
 }

--- a/src/server/snapshots/execution.rs
+++ b/src/server/snapshots/execution.rs
@@ -5,6 +5,7 @@ use crate::hosted_db::paths::{
     pathbuf_to_parent,
 };
 use crate::hosted_db::sqlite::query_sqlite;
+use crate::hosted_db::QueryMode;
 use crate::server::config::{AybConfig, SqliteSnapshotMethod};
 use crate::server::snapshots::hashes::hash_db_directory;
 use crate::server::snapshots::models::{Snapshot, SnapshotType};
@@ -164,13 +165,19 @@ pub async fn snapshot_database(
                 // Run in unsafe mode to allow backup process to
                 // attach to destination database.
                 true,
+                QueryMode::ReadWrite,
             )?;
             if !result.rows.is_empty() {
                 return Err(AybError::SnapshotError {
                     message: format!("Unexpected snapshot result: {:?}", result),
                 });
             }
-            let result = query_sqlite(&snapshot_path, "PRAGMA integrity_check;", false)?;
+            let result = query_sqlite(
+                &snapshot_path,
+                "PRAGMA integrity_check;",
+                false,
+                QueryMode::ReadWrite,
+            )?;
             if result.fields.len() != 1
                 || result.rows.len() != 1
                 || result.rows[0][0] != Some("ok".to_string())

--- a/src/server/snapshots/execution.rs
+++ b/src/server/snapshots/execution.rs
@@ -165,7 +165,7 @@ pub async fn snapshot_database(
                 // Run in unsafe mode to allow backup process to
                 // attach to destination database.
                 true,
-                QueryMode::ReadWrite,
+                QueryMode::ReadOnly,
             )?;
             if !result.rows.is_empty() {
                 return Err(AybError::SnapshotError {
@@ -176,7 +176,7 @@ pub async fn snapshot_database(
                 &snapshot_path,
                 "PRAGMA integrity_check;",
                 false,
-                QueryMode::ReadWrite,
+                QueryMode::ReadOnly,
             )?;
             if result.fields.len() != 1
                 || result.rows.len() != 1

--- a/tests/e2e_tests/permissions_tests.rs
+++ b/tests/e2e_tests/permissions_tests.rs
@@ -1,20 +1,27 @@
-use crate::e2e_tests::FIRST_ENTITY_DB;
-use crate::utils::ayb::{query, update_database};
+use crate::e2e_tests::{FIRST_ENTITY_DB, FIRST_ENTITY_SLUG};
+use crate::utils::ayb::{list_databases, query, update_database};
 use std::collections::HashMap;
 
 pub async fn test_permissions(
     config_path: &str,
     api_keys: &HashMap<String, Vec<String>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // While first entity has access to database (it's the owner), the
-    // second one can't query or find it in list.
+    // While first entity has query access to database and can find it
+    // in a list (it's the owner), the second one can't do either.
     query(
         &config_path,
         &api_keys.get("first").unwrap()[1],
-        "SELECT COUNT(*) AS the_count FROM test_table;",
+        "INSERT INTO test_table (fname, lname) VALUES (\"first permissions1\", \"last permissions1\");",
         FIRST_ENTITY_DB,
         "table",
-        " the_count \n-----------\n 3 \n\nRows: 1",
+        "\nRows: 0",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        "Database slug,Type\ntest.sqlite,sqlite",
     )?;
     query(
         &config_path,
@@ -24,32 +31,52 @@ pub async fn test_permissions(
         "table",
         "Error: Authenticated entity e2e-second can't query database e2e-first/test.sqlite",
     )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        &format!("No queryable databases owned by {}", FIRST_ENTITY_SLUG),
+    )?;
 
-    //TODO(marcua): Implement "can't find database in list" part.
-
-    // Add metadata-only access, ensure you can list but not query
     // Second entity can't update database, but first can.
     update_database(
         &config_path,
         &api_keys.get("second").unwrap()[0],
         FIRST_ENTITY_DB,
-        "metadata",
+        "fork",
         "Error: Authenticated entity e2e-second can't update database e2e-first/test.sqlite",
     )?;
-
     update_database(
         &config_path,
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
-        "metadata",
+        "fork",
         "Database e2e-first/test.sqlite updated successfully",
     )?;
 
-    // TODO(marcua): Implement list, no query checks
+    // With fork-level access, the second entity can't query the database, but can discover it.
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Authenticated entity e2e-second can't query database e2e-first/test.sqlite",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        "Database slug,Type\ntest.sqlite,sqlite",
+    )?;
+    // TODO(marcua): When we implement forking, test that second
+    // entity can fork now, but not before the permission was granted.
 
-    // TODO(marcua): When we support forking, add forking tests.
-
-    // Add public read-only permissions, ensure entity can select but not insert
+    // With public read-only permissions, the second entity can issue
+    // read-only (SELECT) queries, but not modify the database (e.g.,
+    // INSERT). It should also still be able to discover the datbaase.
     update_database(
         &config_path,
         &api_keys.get("first").unwrap()[0],
@@ -57,10 +84,31 @@ pub async fn test_permissions(
         "read-only",
         "Database e2e-first/test.sqlite updated successfully",
     )?;
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        " the_count \n-----------\n 4 \n\nRows: 1",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "INSERT INTO test_table (fname, lname) VALUES (\"first permissions2\", \"last permissions2\");",        
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Attempted to write to a read-only database",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        "Database slug,Type\ntest.sqlite,sqlite",
+    )?;
 
-    // TODO(marcua): Implement list and query checks
-
-    // Remove permissions, ensure entity can't query or find database in list
+    // With no public permissions, the second entity can't query or discover the database.
     update_database(
         &config_path,
         &api_keys.get("first").unwrap()[0],
@@ -68,8 +116,21 @@ pub async fn test_permissions(
         "no-access",
         "Database e2e-first/test.sqlite updated successfully",
     )?;
-
-    // TODO(marcua): Implement no list and no query checks
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Authenticated entity e2e-second can't query database e2e-first/test.sqlite",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        &format!("No queryable databases owned by {}", FIRST_ENTITY_SLUG),
+    )?;
 
     // TODO(marcua): When ready, test entity-database permissions.
     Ok(())

--- a/tests/e2e_tests/permissions_tests.rs
+++ b/tests/e2e_tests/permissions_tests.rs
@@ -98,7 +98,7 @@ pub async fn test_permissions(
         "INSERT INTO test_table (fname, lname) VALUES (\"first permissions2\", \"last permissions2\");",        
         FIRST_ENTITY_DB,
         "table",
-        "Error: Attempted to write to a read-only database",
+        "Error: Attempted to write to database while in read-only mode",
     )?;
     list_databases(
         &config_path,


### PR DESCRIPTION
As part of #281, this PR introduces support for
* Differentiated read-only and read-write access to SQLite databases
* Read-only `query` endpoint support when `public_sharing_level=ReadOnly` and the entity has no other access to the database
* The ability to discover/list databases in `entity_details` with `public_sharing_level=ReadOnly` or `public_sharing_level=Fork` (but no other support for database forking just yet)
* Tests to cover read-only/fork/no-access levels for `public_sharing_level`