### PR TITLE
Database sharing with individual entities

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,5 @@ jobs:
       run: tests/set_up_e2e_env.sh
     - name: Run tests
       run: cargo test --verbose
+      env:
+        RUST_BACKTRACE: 1

--- a/src/ayb_db/db_interfaces.rs
+++ b/src/ayb_db/db_interfaces.rs
@@ -515,6 +515,7 @@ SELECT
     public_sharing_level
 FROM database
 WHERE database.entity_id = $1
+ORDER BY id DESC
                     "#,
                 )
                 .bind(entity.id)

--- a/src/ayb_db/db_interfaces.rs
+++ b/src/ayb_db/db_interfaces.rs
@@ -1,6 +1,7 @@
 use crate::ayb_db::models::{
-    APIToken, AuthenticationMethod, Database, Entity, InstantiatedAuthenticationMethod,
-    InstantiatedDatabase, InstantiatedEntity, PartialDatabase, PartialEntity,
+    APIToken, AuthenticationMethod, Database, Entity, EntityDatabasePermission,
+    InstantiatedAuthenticationMethod, InstantiatedDatabase, InstantiatedEntity, PartialDatabase,
+    PartialEntity,
 };
 use crate::error::AybError;
 use async_trait::async_trait;
@@ -30,6 +31,11 @@ pub trait AybDb: DynClone + Send + Sync {
         method: &AuthenticationMethod,
     ) -> Result<InstantiatedAuthenticationMethod, AybError>;
     async fn create_database(&self, database: &Database) -> Result<InstantiatedDatabase, AybError>;
+    async fn delete_entity_database_permission(
+        &self,
+        entity_id: i32,
+        database_id: i32,
+    ) -> Result<(), AybError>;
     async fn get_or_create_entity(&self, entity: &Entity) -> Result<InstantiatedEntity, AybError>;
     async fn get_api_token(&self, short_token: &str) -> Result<APIToken, AybError>;
     async fn get_database(
@@ -49,6 +55,10 @@ pub trait AybDb: DynClone + Send + Sync {
         entity_id: i32,
         entity: &PartialEntity,
     ) -> Result<InstantiatedEntity, AybError>;
+    async fn update_or_create_entity_database_permission(
+        &self,
+        permission: &EntityDatabasePermission,
+    ) -> Result<(), AybError>;
     async fn list_authentication_methods(
         &self,
         entity: &InstantiatedEntity,
@@ -145,6 +155,25 @@ RETURNING entity_id, short_token, hash, status
 
                 Ok(db)
             }
+
+            async fn delete_entity_database_permission(
+                &self,
+                entity_id: i32,
+                database_id: i32,
+            ) -> Result<(), AybError> {
+                sqlx::query(
+                    r#"
+DELETE FROM entity_database_permission
+WHERE entity_id = $1 AND database_id = $2;
+            "#,
+                )
+                    .bind(entity_id)
+                    .bind(database_id)
+                    .execute(&self.pool)
+                    .await?;
+                Ok(())
+            }
+
 
             async fn get_api_token(
                 &self,
@@ -371,6 +400,28 @@ WHERE id = $1
 
                 Ok(entity)
             }
+
+            async fn update_or_create_entity_database_permission(
+                &self,
+                permission: &EntityDatabasePermission,
+            ) -> Result<(), AybError> {
+                sqlx::query(
+                    r#"
+INSERT INTO entity_database_permission (entity_id, database_id, sharing_level)
+VALUES ($1, $2, $3)
+ON CONFLICT (entity_id, database_id) DO UPDATE
+    SET sharing_level = $3
+            "#,
+                )
+                    .bind(permission.entity_id)
+                    .bind(permission.database_id)
+                    .bind(permission.sharing_level)
+                    .execute(&self.pool)
+                    .await?;
+                Ok(())
+            }
+
+
 
             async fn get_or_create_entity(&self, entity: &Entity) -> Result<InstantiatedEntity, AybError> {
                 // Get or create logic inspired by https://stackoverflow.com/a/66337293

--- a/src/ayb_db/models.rs
+++ b/src/ayb_db/models.rs
@@ -287,26 +287,30 @@ pub struct APIToken {
 )]
 #[repr(i16)]
 pub enum EntityDatabaseSharingLevel {
-    ReadOnly = 0,
-    ReadWrite = 1,
-    Manager = 2,
+    NoAccess = 0,
+    ReadOnly = 1,
+    ReadWrite = 2,
+    Manager = 3,
 }
 
 from_str!(EntityDatabaseSharingLevel, {
+    "no-access" => EntityDatabaseSharingLevel::NoAccess,
     "read-only" => EntityDatabaseSharingLevel::ReadOnly,
     "read-write" => EntityDatabaseSharingLevel::ReadWrite,
     "manager" => EntityDatabaseSharingLevel::Manager
 });
 
 try_from_i16!(EntityDatabaseSharingLevel, {
-    0 => EntityDatabaseSharingLevel::ReadOnly,
-    1 => EntityDatabaseSharingLevel::ReadWrite,
-    2 => EntityDatabaseSharingLevel::Manager
+    0 => EntityDatabaseSharingLevel::NoAccess,
+    1 => EntityDatabaseSharingLevel::ReadOnly,
+    2 => EntityDatabaseSharingLevel::ReadWrite,
+    3 => EntityDatabaseSharingLevel::Manager
 });
 
 impl EntityDatabaseSharingLevel {
     pub fn to_str(&self) -> &str {
         match self {
+            EntityDatabaseSharingLevel::NoAccess => "no-access",
             EntityDatabaseSharingLevel::ReadOnly => "read-only",
             EntityDatabaseSharingLevel::ReadWrite => "read-write",
             EntityDatabaseSharingLevel::Manager => "manager",

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -312,7 +312,7 @@ impl AybClient {
         );
 
         let response = reqwest::Client::new()
-            .patch(self.make_url(format!("{}/{}/share", entity_for_database, database)))
+            .post(self.make_url(format!("{}/{}/share", entity_for_database, database)))
             .headers(headers)
             .send()
             .await?;

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1,4 +1,4 @@
-use crate::ayb_db::models::{DBType, EntityType, PublicSharingLevel};
+use crate::ayb_db::models::{DBType, EntityDatabaseSharingLevel, EntityType, PublicSharingLevel};
 use crate::error::AybError;
 use crate::hosted_db::QueryResult;
 use crate::http::structs::{APIToken, Database, EmptyResponse, EntityQueryResponse, SnapshotList};
@@ -288,6 +288,36 @@ impl AybClient {
             .await?;
 
         self.handle_empty_response(response, reqwest::StatusCode::OK)
+            .await
+    }
+
+    pub async fn share(
+        &self,
+        entity_for_database: &str,
+        database: &str,
+        entity_for_permission: &str,
+        sharing_level: &EntityDatabaseSharingLevel,
+    ) -> Result<(), AybError> {
+        let mut headers = HeaderMap::new();
+        self.add_bearer_token(&mut headers)?;
+
+        headers.insert(
+            HeaderName::from_static("entity-for-permission"),
+            HeaderValue::from_str(entity_for_permission).unwrap(),
+        );
+
+        headers.insert(
+            HeaderName::from_static("sharing-level"),
+            HeaderValue::from_str(sharing_level.to_str()).unwrap(),
+        );
+
+        let response = reqwest::Client::new()
+            .patch(self.make_url(format!("{}/{}/share", entity_for_database, database)))
+            .headers(headers)
+            .send()
+            .await?;
+
+        self.handle_empty_response(response, reqwest::StatusCode::NO_CONTENT)
             .await
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,7 @@ impl Display for AybError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             AybError::Other { message } => write!(f, "{}", message),
+            AybError::CantSetOwnerPermissions { message } => write!(f, "{}", message),
             AybError::NoWriteAccessError { message } => write!(f, "{}", message),
             _ => write!(f, "{:?}", self),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,7 @@ use url;
 #[derive(Debug, Deserialize, Error, Serialize)]
 #[serde(tag = "type")]
 pub enum AybError {
+    CantSetOwnerPermissions { message: String },
     DurationParseError { message: String },
     NoWriteAccessError { message: String },
     S3ExecutionError { message: String },

--- a/src/server/endpoints/entity_database_permission.rs
+++ b/src/server/endpoints/entity_database_permission.rs
@@ -10,7 +10,7 @@ use crate::server::permissions::can_manage_database;
 use crate::server::utils::{get_required_header, unwrap_authenticated_entity};
 use actix_web::{post, web, HttpRequest, HttpResponse};
 
-#[post("/v1/{entity}/{database}/permission")]
+#[post("/v1/{entity}/{database}/share")]
 async fn entity_database_permission(
     path: web::Path<EntityDatabasePath>,
     req: HttpRequest,

--- a/src/server/endpoints/entity_database_permission.rs
+++ b/src/server/endpoints/entity_database_permission.rs
@@ -31,14 +31,14 @@ async fn entity_database_permission(
     if entity_for_permission.id == database.entity_id {
         Err(AybError::CantSetOwnerPermissions {
             message: format!(
-                "{} owns {}/{}, so their permissions are set",
+                "{} owns {}/{}, so their permissions can't be changed",
                 entity_for_permission.slug, entity_for_database_slug, database_slug
             ),
         })
     } else if can_manage_database(&authenticated_entity, &database, &ayb_db).await? {
         if sharing_level == EntityDatabaseSharingLevel::NoAccess {
             ayb_db
-                .delete_entity_database_permission(database.entity_id, database.id)
+                .delete_entity_database_permission(entity_for_permission.id, database.id)
                 .await?;
         } else {
             let permission = EntityDatabasePermission {

--- a/src/server/endpoints/entity_database_permission.rs
+++ b/src/server/endpoints/entity_database_permission.rs
@@ -35,7 +35,7 @@ async fn entity_database_permission(
                 entity_for_permission.slug, entity_for_database_slug, database_slug
             ),
         })
-    } else if can_manage_database(&authenticated_entity, &database) {
+    } else if can_manage_database(&authenticated_entity, &database, &ayb_db).await? {
         if sharing_level == EntityDatabaseSharingLevel::NoAccess {
             ayb_db
                 .delete_entity_database_permission(database.entity_id, database.id)

--- a/src/server/endpoints/entity_database_permission.rs
+++ b/src/server/endpoints/entity_database_permission.rs
@@ -1,0 +1,63 @@
+use crate::ayb_db::db_interfaces::AybDb;
+use crate::ayb_db::models::{
+    EntityDatabasePermission, EntityDatabaseSharingLevel, InstantiatedEntity,
+};
+use std::str::FromStr;
+
+use crate::error::AybError;
+use crate::http::structs::EntityDatabasePath;
+use crate::server::permissions::can_manage_database;
+use crate::server::utils::{get_required_header, unwrap_authenticated_entity};
+use actix_web::{post, web, HttpRequest, HttpResponse};
+
+#[post("/v1/{entity}/{database}/permission")]
+async fn entity_database_permission(
+    path: web::Path<EntityDatabasePath>,
+    req: HttpRequest,
+    ayb_db: web::Data<Box<dyn AybDb>>,
+    authenticated_entity: Option<web::ReqData<InstantiatedEntity>>,
+) -> Result<HttpResponse, AybError> {
+    let entity_for_database_slug = &path.entity.to_lowercase();
+    let database_slug = &path.database;
+    let database = ayb_db
+        .get_database(entity_for_database_slug, database_slug)
+        .await?;
+    let sharing_level =
+        EntityDatabaseSharingLevel::from_str(&get_required_header(&req, "sharing-level")?)?;
+    let entity_for_permission = ayb_db
+        .get_entity_by_slug(&get_required_header(&req, "entity-for-permission")?)
+        .await?;
+    let authenticated_entity = unwrap_authenticated_entity(&authenticated_entity)?;
+    if entity_for_permission.id == database.entity_id {
+        Err(AybError::CantSetOwnerPermissions {
+            message: format!(
+                "{} owns {}/{}, so their permissions are set",
+                entity_for_permission.slug, entity_for_database_slug, database_slug
+            ),
+        })
+    } else if can_manage_database(&authenticated_entity, &database) {
+        if sharing_level == EntityDatabaseSharingLevel::NoAccess {
+            ayb_db
+                .delete_entity_database_permission(database.entity_id, database.id)
+                .await?;
+        } else {
+            let permission = EntityDatabasePermission {
+                entity_id: entity_for_permission.id,
+                database_id: database.id,
+                sharing_level: sharing_level as i16,
+            };
+            ayb_db
+                .update_or_create_entity_database_permission(&permission)
+                .await?;
+        }
+
+        Ok(HttpResponse::NoContent().into())
+    } else {
+        Err(AybError::Other {
+            message: format!(
+                "Authenticated entity {} can't set permissions for database {}/{}",
+                authenticated_entity.slug, entity_for_database_slug, database_slug
+            ),
+        })
+    }
+}

--- a/src/server/endpoints/entity_details.rs
+++ b/src/server/endpoints/entity_details.rs
@@ -18,7 +18,7 @@ pub async fn entity_details(
 
     let mut databases = Vec::new();
     for database in ayb_db.list_databases_by_entity(&desired_entity).await? {
-        if can_discover_database(&authenticated_entity, &database)? {
+        if can_discover_database(&authenticated_entity, &database, &ayb_db).await? {
             databases.push(database.into());
         }
     }

--- a/src/server/endpoints/list_snapshots.rs
+++ b/src/server/endpoints/list_snapshots.rs
@@ -4,7 +4,7 @@ use crate::ayb_db::models::InstantiatedEntity;
 use crate::error::AybError;
 use crate::http::structs::{EntityDatabasePath, SnapshotList};
 use crate::server::config::AybConfig;
-use crate::server::permissions::can_manage_snapshots;
+use crate::server::permissions::can_manage_database;
 use crate::server::snapshots::models::ListSnapshotResult;
 use crate::server::snapshots::storage::SnapshotStorage;
 use crate::server::utils::unwrap_authenticated_entity;
@@ -22,7 +22,7 @@ async fn list_snapshots(
     let database = ayb_db.get_database(entity_slug, database_slug).await?;
     let authenticated_entity = unwrap_authenticated_entity(&authenticated_entity)?;
 
-    if can_manage_snapshots(&authenticated_entity, &database) {
+    if can_manage_database(&authenticated_entity, &database, &ayb_db).await? {
         let mut recent_snapshots: Vec<ListSnapshotResult> = Vec::new();
         if let Some(ref snapshot_config) = ayb_config.snapshots {
             let snapshot_storage = SnapshotStorage::new(snapshot_config).await?;

--- a/src/server/endpoints/mod.rs
+++ b/src/server/endpoints/mod.rs
@@ -1,23 +1,23 @@
 mod confirm;
 mod create_database;
-mod entity_database_permission;
 mod entity_details;
 mod list_snapshots;
 mod log_in;
 mod query;
 mod register;
 mod restore_snapshot;
+mod share;
 mod update_database;
 mod update_profile;
 
 pub use confirm::confirm as confirm_endpoint;
 pub use create_database::create_database as create_db_endpoint;
-pub use entity_database_permission::entity_database_permission as entity_database_permission_endpoint;
 pub use entity_details::entity_details as entity_details_endpoint;
 pub use list_snapshots::list_snapshots as list_snapshots_endpoint;
 pub use log_in::log_in as log_in_endpoint;
 pub use query::query as query_endpoint;
 pub use register::register as register_endpoint;
 pub use restore_snapshot::restore_snapshot as restore_snapshot_endpoint;
+pub use share::share as share_endpoint;
 pub use update_database::update_database as update_db_endpoint;
 pub use update_profile::update_profile as update_profile_endpoint;

--- a/src/server/endpoints/mod.rs
+++ b/src/server/endpoints/mod.rs
@@ -1,5 +1,6 @@
 mod confirm;
 mod create_database;
+mod entity_database_permission;
 mod entity_details;
 mod list_snapshots;
 mod log_in;
@@ -11,6 +12,7 @@ mod update_profile;
 
 pub use confirm::confirm as confirm_endpoint;
 pub use create_database::create_database as create_db_endpoint;
+pub use entity_database_permission::entity_database_permission as entity_database_permission_endpoint;
 pub use entity_details::entity_details as entity_details_endpoint;
 pub use list_snapshots::list_snapshots as list_snapshots_endpoint;
 pub use log_in::log_in as log_in_endpoint;

--- a/src/server/endpoints/query.rs
+++ b/src/server/endpoints/query.rs
@@ -23,7 +23,8 @@ async fn query(
     let database = ayb_db.get_database(entity_slug, database_slug).await?;
     let authenticated_entity = unwrap_authenticated_entity(&authenticated_entity)?;
 
-    let access_level = highest_query_access_level(&authenticated_entity, &database)?;
+    let access_level =
+        highest_query_access_level(&authenticated_entity, &database, &ayb_db).await?;
     match access_level {
         Some(access_level) => {
             let db_type = DBType::try_from(database.db_type)?;

--- a/src/server/endpoints/restore_snapshot.rs
+++ b/src/server/endpoints/restore_snapshot.rs
@@ -4,7 +4,7 @@ use crate::error::AybError;
 use crate::hosted_db::paths::{new_database_path, set_current_database_and_clean_up};
 use crate::http::structs::{EmptyResponse, EntityDatabasePath};
 use crate::server::config::AybConfig;
-use crate::server::permissions::can_manage_snapshots;
+use crate::server::permissions::can_manage_database;
 use crate::server::snapshots::storage::SnapshotStorage;
 use crate::server::utils::unwrap_authenticated_entity;
 use actix_web::{post, web, HttpResponse};
@@ -22,7 +22,7 @@ async fn restore_snapshot(
     let database = ayb_db.get_database(entity_slug, database_slug).await?;
     let authenticated_entity = unwrap_authenticated_entity(&authenticated_entity)?;
 
-    if can_manage_snapshots(&authenticated_entity, &database) {
+    if can_manage_database(&authenticated_entity, &database, &ayb_db).await? {
         if let Some(ref snapshot_config) = ayb_config.snapshots {
             // TODO(marcua): In the future, consider quiescing
             // requests to this database during the process, and

--- a/src/server/endpoints/share.rs
+++ b/src/server/endpoints/share.rs
@@ -11,7 +11,7 @@ use crate::server::utils::{get_required_header, unwrap_authenticated_entity};
 use actix_web::{post, web, HttpRequest, HttpResponse};
 
 #[post("/v1/{entity}/{database}/share")]
-async fn entity_database_permission(
+async fn share(
     path: web::Path<EntityDatabasePath>,
     req: HttpRequest,
     ayb_db: web::Data<Box<dyn AybDb>>,

--- a/src/server/endpoints/update_database.rs
+++ b/src/server/endpoints/update_database.rs
@@ -19,7 +19,7 @@ async fn update_database(
     let database_slug = &path.database;
     let database = ayb_db.get_database(entity_slug, database_slug).await?;
     let authenticated_entity = unwrap_authenticated_entity(&authenticated_entity)?;
-    if can_manage_database(&authenticated_entity, &database) {
+    if can_manage_database(&authenticated_entity, &database, &ayb_db).await? {
         let public_sharing_level = get_optional_header(&req, "public-sharing-level")?;
         let mut partial_database = PartialDatabase {
             public_sharing_level: None,

--- a/src/server/permissions.rs
+++ b/src/server/permissions.rs
@@ -94,11 +94,3 @@ pub async fn highest_query_access_level(
         }
     }
 }
-
-pub fn can_manage_snapshots(
-    authenticated_entity: &InstantiatedEntity,
-    database: &InstantiatedDatabase,
-) -> bool {
-    // An entity/user can only manage snapshots on its own databases (for now)
-    is_owner(authenticated_entity, database)
-}

--- a/src/server/permissions.rs
+++ b/src/server/permissions.rs
@@ -94,5 +94,5 @@ pub async fn highest_query_access_level(
         return Ok(Some(QueryMode::ReadOnly));
     }
 
-    return Ok(None);
+    Ok(None)
 }

--- a/src/server/server_runner.rs
+++ b/src/server/server_runner.rs
@@ -4,9 +4,9 @@ use crate::error::AybError;
 use crate::server::config::read_config;
 use crate::server::config::AybConfigCors;
 use crate::server::endpoints::{
-    confirm_endpoint, create_db_endpoint, entity_database_permission_endpoint,
-    entity_details_endpoint, list_snapshots_endpoint, log_in_endpoint, query_endpoint,
-    register_endpoint, restore_snapshot_endpoint, update_db_endpoint, update_profile_endpoint,
+    confirm_endpoint, create_db_endpoint, entity_details_endpoint, list_snapshots_endpoint,
+    log_in_endpoint, query_endpoint, register_endpoint, restore_snapshot_endpoint, share_endpoint,
+    update_db_endpoint, update_profile_endpoint,
 };
 use crate::server::snapshots::execution::schedule_periodic_snapshots;
 use crate::server::tokens::retrieve_and_validate_api_token;
@@ -30,11 +30,11 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             .service(create_db_endpoint)
             .service(update_db_endpoint)
             .service(query_endpoint)
-            .service(entity_database_permission_endpoint)
             .service(entity_details_endpoint)
             .service(update_profile_endpoint)
             .service(list_snapshots_endpoint)
-            .service(restore_snapshot_endpoint),
+            .service(restore_snapshot_endpoint)
+            .service(share_endpoint),
     );
 }
 

--- a/src/server/server_runner.rs
+++ b/src/server/server_runner.rs
@@ -4,9 +4,9 @@ use crate::error::AybError;
 use crate::server::config::read_config;
 use crate::server::config::AybConfigCors;
 use crate::server::endpoints::{
-    confirm_endpoint, create_db_endpoint, entity_details_endpoint, list_snapshots_endpoint,
-    log_in_endpoint, query_endpoint, register_endpoint, restore_snapshot_endpoint,
-    update_db_endpoint, update_profile_endpoint,
+    confirm_endpoint, create_db_endpoint, entity_database_permission_endpoint,
+    entity_details_endpoint, list_snapshots_endpoint, log_in_endpoint, query_endpoint,
+    register_endpoint, restore_snapshot_endpoint, update_db_endpoint, update_profile_endpoint,
 };
 use crate::server::snapshots::execution::schedule_periodic_snapshots;
 use crate::server::tokens::retrieve_and_validate_api_token;
@@ -30,6 +30,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             .service(create_db_endpoint)
             .service(update_db_endpoint)
             .service(query_endpoint)
+            .service(entity_database_permission_endpoint)
             .service(entity_details_endpoint)
             .service(update_profile_endpoint)
             .service(list_snapshots_endpoint)

--- a/tests/e2e_tests/create_and_query_db_tests.rs
+++ b/tests/e2e_tests/create_and_query_db_tests.rs
@@ -1,4 +1,4 @@
-use crate::e2e_tests::{FIRST_ENTITY_DB, FIRST_ENTITY_DB_CASED};
+use crate::e2e_tests::{FIRST_ENTITY_DB, FIRST_ENTITY_DB2, FIRST_ENTITY_DB_CASED};
 use crate::utils::ayb::{create_database, query, query_no_api_token, set_default_url};
 use ayb::client::config::ClientConfig;
 use std::collections::HashMap;
@@ -14,6 +14,7 @@ pub fn test_create_and_query_db(
     create_database(
         &config_path,
         &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
         "Error: Authenticated entity e2e-second can't create a database for entity e2e-first",
     )?;
 
@@ -21,6 +22,7 @@ pub fn test_create_and_query_db(
     create_database(
         &config_path,
         &format!("{}bad", api_keys.get("first").unwrap()[0]),
+        FIRST_ENTITY_DB,
         "Error: Invalid API token",
     )?;
 
@@ -28,6 +30,7 @@ pub fn test_create_and_query_db(
     create_database(
         &config_path,
         &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
         "Successfully created e2e-first/test.sqlite",
     )?;
 
@@ -35,7 +38,16 @@ pub fn test_create_and_query_db(
     create_database(
         &config_path,
         &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
         "Error: Database already exists",
+    )?;
+
+    // Can create another database with the appropriate user/key pair.
+    create_database(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB2,
+        "Successfully created e2e-first/another.sqlite",
     )?;
 
     // Can't query database with second account's API key

--- a/tests/e2e_tests/entity_details_and_profile_tests.rs
+++ b/tests/e2e_tests/entity_details_and_profile_tests.rs
@@ -12,7 +12,7 @@ pub fn test_entity_details_and_profile(
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_SLUG_CASED, // Entity slugs should be case-insensitive
         "csv",
-        "Database slug,Type\ntest.sqlite,sqlite",
+        "Database slug,Type\nanother.sqlite,sqlite\ntest.sqlite,sqlite",
     )?;
 
     // List databases from first account using the API key of the second account

--- a/tests/e2e_tests/mod.rs
+++ b/tests/e2e_tests/mod.rs
@@ -12,6 +12,7 @@ pub use snapshot_tests::test_snapshots;
 
 const FIRST_ENTITY_DB: &str = "e2e-first/test.sqlite";
 const FIRST_ENTITY_DB_CASED: &str = "E2E-FiRST/test.sqlite";
+const FIRST_ENTITY_DB2: &str = "e2e-first/another.sqlite";
 const FIRST_ENTITY_DB_SLUG: &str = "test.sqlite";
 const FIRST_ENTITY_SLUG: &str = "e2e-first";
 const FIRST_ENTITY_SLUG_CASED: &str = "E2E-FiRsT";

--- a/tests/e2e_tests/mod.rs
+++ b/tests/e2e_tests/mod.rs
@@ -16,3 +16,4 @@ const FIRST_ENTITY_DB_SLUG: &str = "test.sqlite";
 const FIRST_ENTITY_SLUG: &str = "e2e-first";
 const FIRST_ENTITY_SLUG_CASED: &str = "E2E-FiRsT";
 const SECOND_ENTITY_SLUG: &str = "e2e-second";
+const THIRD_ENTITY_SLUG: &str = "e2e-third";

--- a/tests/e2e_tests/permissions_tests.rs
+++ b/tests/e2e_tests/permissions_tests.rs
@@ -262,7 +262,15 @@ pub async fn test_permissions(
         "table",
         " the_count \n-----------\n 4 \n\nRows: 1",
     )?;
-    // Second entity can modify database.
+    // Even if the public sharing level of the database is read-only,
+    // the second entity will be able to modify the database.
+    update_database(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "read-only",
+        "Database e2e-first/test.sqlite updated successfully",
+    )?;
     query(
         &config_path,
         &api_keys.get("second").unwrap()[0],
@@ -270,6 +278,13 @@ pub async fn test_permissions(
         FIRST_ENTITY_DB,
         "table",
         "\nRows: 0",
+    )?;
+    update_database(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "no-access",
+        "Database e2e-first/test.sqlite updated successfully",
     )?;
     // Second entity can discover database.
     list_databases(

--- a/tests/e2e_tests/permissions_tests.rs
+++ b/tests/e2e_tests/permissions_tests.rs
@@ -1,5 +1,7 @@
-use crate::e2e_tests::{FIRST_ENTITY_DB, FIRST_ENTITY_SLUG};
-use crate::utils::ayb::{list_databases, query, update_database};
+use crate::e2e_tests::{FIRST_ENTITY_DB, FIRST_ENTITY_SLUG, SECOND_ENTITY_SLUG, THIRD_ENTITY_SLUG};
+use crate::utils::ayb::{
+    list_databases, list_snapshots, list_snapshots_match_output, query, share, update_database,
+};
 use std::collections::HashMap;
 
 pub async fn test_permissions(
@@ -132,6 +134,344 @@ pub async fn test_permissions(
         &format!("No queryable databases owned by {}", FIRST_ENTITY_SLUG),
     )?;
 
-    // TODO(marcua): When ready, test entity-database permissions.
+    // Ensure we can't update permissions for owner, even if we're ourselves.
+    share(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        FIRST_ENTITY_SLUG,
+        "no-access",
+        "Error: e2e-first owns e2e-first/test.sqlite, so their permissions can't be changed",
+    )?;
+
+    // First entity grants second entity read-only access (discovery,
+    // read-only queries, but no snapshots, permissions, or metadata
+    // updates). We'll confirm second entity's access, then ensure
+    // third entity (unrelated) has no access.
+    share(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        SECOND_ENTITY_SLUG,
+        "read-only",
+        "Permissions for e2e-second on e2e-first/test.sqlite updated successfully",
+    )?;
+    // Second entity has read-only access.
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        " the_count \n-----------\n 4 \n\nRows: 1",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "INSERT INTO test_table (fname, lname) VALUES (\"first permissions2\", \"last permissions2\");",        
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Attempted to write to database while in read-only mode",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        "Database slug,Type\ntest.sqlite,sqlite",
+    )?;
+    list_snapshots_match_output(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "csv",
+        "Error: Authenticated entity e2e-second can't manage snapshots on database e2e-first/test.sqlite",
+    )?;
+    update_database(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "fork",
+        "Error: Authenticated entity e2e-second can't update database e2e-first/test.sqlite",
+    )?;
+    share(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        THIRD_ENTITY_SLUG,
+        "read-only",
+        "Error: Authenticated entity e2e-second can\'t set permissions for database e2e-first/test.sqlite",
+    )?;
+    // Third entity has no access.
+    query(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Authenticated entity e2e-third can't query database e2e-first/test.sqlite",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        &format!("No queryable databases owned by {}", FIRST_ENTITY_SLUG),
+    )?;
+
+    // Second entity has read-write access (discovery, read-write
+    // queries, but no snapshots, permissions, or metadata updates).
+    share(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        SECOND_ENTITY_SLUG,
+        "read-write",
+        "Permissions for e2e-second on e2e-first/test.sqlite updated successfully",
+    )?;
+    // Second entity has read-write access.
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        " the_count \n-----------\n 4 \n\nRows: 1",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "INSERT INTO test_table (fname, lname) VALUES (\"first permissions2\", \"last permissions2\");",        
+        FIRST_ENTITY_DB,
+        "table",
+        "\nRows: 0",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        "Database slug,Type\ntest.sqlite,sqlite",
+    )?;
+    list_snapshots_match_output(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "csv",
+        "Error: Authenticated entity e2e-second can't manage snapshots on database e2e-first/test.sqlite",
+    )?;
+    update_database(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "fork",
+        "Error: Authenticated entity e2e-second can't update database e2e-first/test.sqlite",
+    )?;
+    share(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        THIRD_ENTITY_SLUG,
+        "read-only",
+        "Error: Authenticated entity e2e-second can\'t set permissions for database e2e-first/test.sqlite",
+    )?;
+    // Third entity has no access.
+    query(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Authenticated entity e2e-third can't query database e2e-first/test.sqlite",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        &format!("No queryable databases owned by {}", FIRST_ENTITY_SLUG),
+    )?;
+
+    // Second entity has manager access (discovery, read-write
+    // queries, snapshots, permissions, and metadata
+    // updates). Initially, third doesn't have any access, but second
+    // grants it access via public settings and then entity-database
+    // sharing level settings. At no point can the second entity
+    // change the first (owner)'s access.
+    share(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        SECOND_ENTITY_SLUG,
+        "manager",
+        "Permissions for e2e-second on e2e-first/test.sqlite updated successfully",
+    )?;
+    // Second entity has read-write access.
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        " the_count \n-----------\n 5 \n\nRows: 1",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "INSERT INTO test_table (fname, lname) VALUES (\"first permissions2\", \"last permissions2\");",        
+        FIRST_ENTITY_DB,
+        "table",
+        "\nRows: 0",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        "Database slug,Type\ntest.sqlite,sqlite",
+    )?;
+    let snapshots = list_snapshots(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "csv",
+    )?;
+    assert_ne!(
+        snapshots.len(),
+        0,
+        "e2e-second should be able to list snapshots"
+    );
+    update_database(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "read-only",
+        "Database e2e-first/test.sqlite updated successfully",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        " the_count \n-----------\n 6 \n\nRows: 1",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        "INSERT INTO test_table (fname, lname) VALUES (\"first permissions2\", \"last permissions2\");",        
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Attempted to write to database while in read-only mode",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        "Database slug,Type\ntest.sqlite,sqlite",
+    )?;
+    update_database(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        "no-access",
+        "Database e2e-first/test.sqlite updated successfully",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Authenticated entity e2e-third can't query database e2e-first/test.sqlite",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        &format!("No queryable databases owned by {}", FIRST_ENTITY_SLUG),
+    )?;
+
+    share(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        THIRD_ENTITY_SLUG,
+        "read-only",
+        "Permissions for e2e-third on e2e-first/test.sqlite updated successfully",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        " the_count \n-----------\n 6 \n\nRows: 1",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        "INSERT INTO test_table (fname, lname) VALUES (\"first permissions2\", \"last permissions2\");",        
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Attempted to write to database while in read-only mode",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        "Database slug,Type\ntest.sqlite,sqlite",
+    )?;
+    share(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_DB,
+        THIRD_ENTITY_SLUG,
+        "no-access",
+        "Permissions for e2e-third on e2e-first/test.sqlite updated successfully",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Authenticated entity e2e-third can't query database e2e-first/test.sqlite",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("third").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        &format!("No queryable databases owned by {}", FIRST_ENTITY_SLUG),
+    )?;
+
+    share(
+        &config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        SECOND_ENTITY_SLUG,
+        "no-access",
+        "Permissions for e2e-second on e2e-first/test.sqlite updated successfully",
+    )?;
+    query(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        "SELECT COUNT(*) AS the_count FROM test_table;",
+        FIRST_ENTITY_DB,
+        "table",
+        "Error: Authenticated entity e2e-second can't query database e2e-first/test.sqlite",
+    )?;
+    list_databases(
+        &config_path,
+        &api_keys.get("second").unwrap()[0],
+        FIRST_ENTITY_SLUG,
+        "csv",
+        &format!("No queryable databases owned by {}", FIRST_ENTITY_SLUG),
+    )?;
+
     Ok(())
 }

--- a/tests/utils/ayb.rs
+++ b/tests/utils/ayb.rs
@@ -243,3 +243,19 @@ pub fn update_database(
     cmd.stdout(format!("{}\n", result));
     Ok(())
 }
+
+pub fn share(
+    config: &str,
+    api_key: &str,
+    database: &str,
+    entity: &str,
+    sharing_level: &str,
+    result: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cmd = ayb_assert_cmd!("client", "--config", config, "share", database, entity, sharing_level; {
+        "AYB_API_TOKEN" => api_key,
+    });
+
+    cmd.stdout(format!("{}\n", result));
+    Ok(())
+}

--- a/tests/utils/ayb.rs
+++ b/tests/utils/ayb.rs
@@ -22,9 +22,10 @@ macro_rules! ayb_assert_cmd {
 pub fn create_database(
     config: &str,
     api_key: &str,
+    database: &str,
     result: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let cmd = ayb_assert_cmd!("client", "--config", config, "create_database", "e2e-first/test.sqlite", "sqlite"; {
+    let cmd = ayb_assert_cmd!("client", "--config", config, "create_database", database, "sqlite"; {
         "AYB_API_TOKEN" => api_key,
     });
 


### PR DESCRIPTION
As part of #281, introduces entity-level permissions to databases:
* A `share` endpoint allows managers and owners to set/revoke permissions for other entities via new database CRUD functionality for `EntityDatabasePermission`, and the CLI/HTTP client library can call the share endpoint.
* Permissions checks will (as a last resort, after testing for ownership/public sharing levels, which require no additional database round-trips) retrieve any specific permissions for this (entity, database) combination.
* End-to-end tests to cover the new functionality, including a new database and entity to ensure that permissions changes only affect the relevant entity/database.