### PR TITLE
Skip isolation with a warning when not on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tests/nsjail
 tests/localstack_init.sh
 tests/localstack_data*
 tests/test-env
+.aider*

--- a/README.md
+++ b/README.md
@@ -309,16 +309,18 @@ flag and sets
 to `0` in order to prevent users from corrupting the database or
 attaching to other databases on the filesystem.
 
-For further isolation, `ayb` uses [nsjail](https://nsjail.dev/) to
-isolate each query's filesystem access and resources. When this form
-of isolation is enabled, `ayb` starts a new `nsjail`-managed process
-to execute the query against the database. We have not yet benchmarked
-the performance overhead of this approach.
+For further isolation, `ayb` can use [nsjail](https://nsjail.dev/)
+(only when running on Linux) to isolate each query's filesystem access
+and resources. When this form of isolation is enabled, `ayb` starts a
+new `nsjail`-managed process to execute the query against the
+database. We have not yet benchmarked the performance overhead of this
+approach.
 
-To enable isolation, you must first build `nsjail`, which you can do
-through [scripts/build_nsjail.sh](scripts/build_nsjail.sh). Note that
-`nsjail` depends on a few other packages. If you run into issues
-building it, it might be helpful to see its
+To enable this deeper form of isolation on Linux, you must first build
+`nsjail`, which you can do through
+[scripts/build_nsjail.sh](scripts/build_nsjail.sh). Note that `nsjail`
+depends on a few other packages. If you run into issues building it,
+it might be helpful to see its
 [Dockerfile](https://github.com/google/nsjail/blob/master/Dockerfile)
 to get a sense of those requirements.
 

--- a/src/server/server_runner.rs
+++ b/src/server/server_runner.rs
@@ -3,7 +3,6 @@ use crate::ayb_db::db_interfaces::AybDb;
 use crate::error::AybError;
 use crate::server::config::read_config;
 use crate::server::config::AybConfigCors;
-use std::env::consts::OS;
 use crate::server::endpoints::{
     confirm_endpoint, create_db_endpoint, entity_details_endpoint, list_snapshots_endpoint,
     log_in_endpoint, query_endpoint, register_endpoint, restore_snapshot_endpoint, share_endpoint,
@@ -18,6 +17,7 @@ use actix_web::{middleware, web, App, Error, HttpMessage, HttpServer};
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use actix_web_httpauth::middleware::HttpAuthentication;
 use dyn_clone::clone_box;
+use std::env::consts::OS;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -108,7 +108,10 @@ pub async fn run_server(config_path: &PathBuf) -> std::io::Result<()> {
     if ayb_conf.isolation.is_none() {
         println!("Note: Server is running without full isolation. Read more about isolating users from one-another: https://github.com/marcua/ayb/#isolation");
     } else if OS != "linux" {
-        println!("Warning: nsjail isolation is only supported on Linux. Running without isolation on {}", OS);
+        println!(
+            "Warning: nsjail isolation is only supported on Linux. Running without isolation on {}",
+            OS
+        );
         ayb_conf_for_server.isolation = None;
     } else {
         let isolation = ayb_conf.isolation.unwrap();


### PR DESCRIPTION
An `ayb` server will now warn you but keep running if `nsjail`-based isolation is configured but you're not running on Linux (allows tests to run on other operating systems).