### PR TITLE
Remove unused test field and utils

### DIFF
--- a/tests/browser_e2e_tests/oauth_flow.rs
+++ b/tests/browser_e2e_tests/oauth_flow.rs
@@ -31,7 +31,6 @@ fn generate_pkce() -> (String, String) {
 /// Result of completing the OAuth authorization flow
 struct OAuthTokenResult {
     access_token: String,
-    permission_level: String,
 }
 
 /// Complete the OAuth authorization flow and exchange for a token.
@@ -178,10 +177,7 @@ async fn complete_oauth_flow(
 
     println!("Received scoped token with {} permission", permission_level);
 
-    Ok(OAuthTokenResult {
-        access_token,
-        permission_level,
-    })
+    Ok(OAuthTokenResult { access_token })
 }
 
 /// Test the OAuth flow with a read-only scoped token.

--- a/tests/utils/ayb.rs
+++ b/tests/utils/ayb.rs
@@ -92,28 +92,6 @@ pub fn register(
     Ok(())
 }
 
-pub fn log_in(
-    server_url: &str,
-    username: &str,
-    result: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let cmd = ayb_assert_cmd!("client", "--url", server_url, "log_in", username; {});
-
-    cmd.stdout(format!("{result}\n"));
-    Ok(())
-}
-
-pub fn confirm(
-    server_url: &str,
-    token: &str,
-    result: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let cmd = ayb_assert_cmd!("client", "--url", server_url, "confirm", token; {});
-
-    cmd.stdout(predicate::str::contains(result));
-    Ok(())
-}
-
 pub fn list_databases(
     config: &str,
     api_key: &str,


### PR DESCRIPTION
Addresses these warnings

```
warning: field permission_level is never read
  --> tests/browser_e2e_tests/oauth_flow.rs:34:5
   |
32 | struct OAuthTokenResult {
   |        ---------------- field in this struct
33 |     access_token: String,
34 |     permission_level: String,
   |     ^^^^^^^^^^^^^^^^
   |
   = note: #[warn(dead_code)] (part of #[warn(unused)]) on by default

warning: function log_in is never used
  --> tests/utils/ayb.rs:95:8
   |
95 | pub fn log_in(
   |        ^^^^^^

warning: function confirm is never used
   --> tests/utils/ayb.rs:106:8
    |
106 | pub fn confirm(
    |        ^^^^^^^

warning: ayb (test "e2e") generated 3 warnings
```