### PR TITLE
Fix flaky snapshot test

### DIFF
--- a/tests/browser_e2e_tests/snapshots.rs
+++ b/tests/browser_e2e_tests/snapshots.rs
@@ -2,49 +2,6 @@ use crate::utils::browser::BrowserHelpers;
 use playwright::api::Page;
 use std::error::Error;
 
-/// Poll the Snapshots tab until it shows at least `min_count` snapshot
-/// rows, then switch back to the Query tab so the caller can continue.
-async fn wait_for_browser_snapshot(page: &Page, min_count: usize) -> Result<(), Box<dyn Error>> {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
-    loop {
-        page.click_builder("a[href='#snapshots']")
-            .timeout(5000.0)
-            .click()
-            .await?;
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-        let row_count: serde_json::Value = page
-            .evaluate(
-                "document.querySelectorAll('#snapshots tbody tr').length",
-                serde_json::Value::Null,
-            )
-            .await?;
-        let count = row_count.as_u64().unwrap_or(0) as usize;
-
-        if count >= min_count || std::time::Instant::now() >= deadline {
-            assert!(
-                count >= min_count,
-                "expected at least {} snapshot rows in UI but found {}",
-                min_count,
-                count
-            );
-            // Switch back to Query tab
-            page.click_builder("a[href='#query']")
-                .timeout(5000.0)
-                .click()
-                .await?;
-            return Ok(());
-        }
-
-        // Switch back to Query tab before retrying
-        page.click_builder("a[href='#query']")
-            .timeout(5000.0)
-            .click()
-            .await?;
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    }
-}
-
 pub async fn test_snapshots_flow(
     page: &Page,
     username: &str,
@@ -85,10 +42,9 @@ pub async fn test_snapshots_flow(
     let page_text = page.inner_text("#query-results", None).await?;
     assert!(page_text.contains("2"), "Initial count should show 2 rows");
 
-    // Step 3: Wait for automatic snapshot to be created (snapshots are auto-created after DB changes).
-    // Poll the Snapshots tab until at least one snapshot row appears, rather than
-    // using a fixed sleep that races with the background daemon.
-    wait_for_browser_snapshot(page, 1).await?;
+    // Step 3: Wait for automatic snapshot to be created (snapshots are auto-created after DB changes)
+    // The system takes snapshots automatically every 2 seconds when database changes
+    tokio::time::sleep(std::time::Duration::from_millis(3000)).await;
 
     // Step 4: Insert a new row
     let insert_query = "INSERT INTO test_table (fname, lname) VALUES (\"snapshot\", \"test\");";
@@ -133,8 +89,8 @@ pub async fn test_snapshots_flow(
         "Count after insert should show 3 rows"
     );
 
-    // Step 6: Wait for daemon to create a snapshot of the new database state.
-    wait_for_browser_snapshot(page, 2).await?;
+    // Step 6: Sleep to allow automatic snapshot after insert
+    tokio::time::sleep(std::time::Duration::from_millis(3000)).await;
 
     // Step 7: Click the Snapshots tab to see available snapshots
     // This triggers the proper tab switching and AJAX loading of snapshots

--- a/tests/browser_e2e_tests/snapshots.rs
+++ b/tests/browser_e2e_tests/snapshots.rs
@@ -2,6 +2,49 @@ use crate::utils::browser::BrowserHelpers;
 use playwright::api::Page;
 use std::error::Error;
 
+/// Poll the Snapshots tab until it shows at least `min_count` snapshot
+/// rows, then switch back to the Query tab so the caller can continue.
+async fn wait_for_browser_snapshot(page: &Page, min_count: usize) -> Result<(), Box<dyn Error>> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        page.click_builder("a[href='#snapshots']")
+            .timeout(5000.0)
+            .click()
+            .await?;
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let row_count: serde_json::Value = page
+            .evaluate(
+                "document.querySelectorAll('#snapshots tbody tr').length",
+                serde_json::Value::Null,
+            )
+            .await?;
+        let count = row_count.as_u64().unwrap_or(0) as usize;
+
+        if count >= min_count || std::time::Instant::now() >= deadline {
+            assert!(
+                count >= min_count,
+                "expected at least {} snapshot rows in UI but found {}",
+                min_count,
+                count
+            );
+            // Switch back to Query tab
+            page.click_builder("a[href='#query']")
+                .timeout(5000.0)
+                .click()
+                .await?;
+            return Ok(());
+        }
+
+        // Switch back to Query tab before retrying
+        page.click_builder("a[href='#query']")
+            .timeout(5000.0)
+            .click()
+            .await?;
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+}
+
 pub async fn test_snapshots_flow(
     page: &Page,
     username: &str,
@@ -42,9 +85,10 @@ pub async fn test_snapshots_flow(
     let page_text = page.inner_text("#query-results", None).await?;
     assert!(page_text.contains("2"), "Initial count should show 2 rows");
 
-    // Step 3: Wait for automatic snapshot to be created (snapshots are auto-created after DB changes)
-    // The system takes snapshots automatically every 2 seconds when database changes
-    tokio::time::sleep(std::time::Duration::from_millis(3000)).await;
+    // Step 3: Wait for automatic snapshot to be created (snapshots are auto-created after DB changes).
+    // Poll the Snapshots tab until at least one snapshot row appears, rather than
+    // using a fixed sleep that races with the background daemon.
+    wait_for_browser_snapshot(page, 1).await?;
 
     // Step 4: Insert a new row
     let insert_query = "INSERT INTO test_table (fname, lname) VALUES (\"snapshot\", \"test\");";
@@ -89,8 +133,8 @@ pub async fn test_snapshots_flow(
         "Count after insert should show 3 rows"
     );
 
-    // Step 6: Sleep to allow automatic snapshot after insert
-    tokio::time::sleep(std::time::Duration::from_millis(3000)).await;
+    // Step 6: Wait for daemon to create a snapshot of the new database state.
+    wait_for_browser_snapshot(page, 2).await?;
 
     // Step 7: Click the Snapshots tab to see available snapshots
     // This triggers the proper tab switching and AJAX loading of snapshots

--- a/tests/e2e_tests/snapshot_tests.rs
+++ b/tests/e2e_tests/snapshot_tests.rs
@@ -33,6 +33,34 @@ fn wait_for_snapshot_count(
     }
 }
 
+/// Wait until the newest snapshot ID differs from `prev_newest_id`,
+/// then return the current snapshot list. This is needed for the
+/// pruning test where the count stays the same (6 → 7 → 6) but the
+/// contents change.
+fn wait_for_new_snapshot(
+    config_path: &str,
+    api_key: &str,
+    database: &str,
+    prev_newest_id: &str,
+    timeout_secs: u64,
+) -> Vec<ayb::server::snapshots::models::ListSnapshotResult> {
+    let deadline = time::Instant::now() + time::Duration::from_secs(timeout_secs);
+    loop {
+        thread::sleep(time::Duration::from_secs(2));
+        let snapshots = list_snapshots(config_path, api_key, database, "csv")
+            .expect("failed to list snapshots");
+        let newest_changed = !snapshots.is_empty() && snapshots[0].snapshot_id != prev_newest_id;
+        if newest_changed || time::Instant::now() >= deadline {
+            assert!(
+                newest_changed,
+                "newest snapshot did not change from {} within {}s",
+                prev_newest_id, timeout_secs
+            );
+            return snapshots;
+        }
+    }
+}
+
 pub async fn test_snapshots(
     db_type: &str,
     config_path: &str,
@@ -63,14 +91,12 @@ pub async fn test_snapshots(
         )
         .await?;
 
-    // Can list snapshots from the first set of API keys.
-    list_snapshots_match_output(
-        config_path,
-        &api_keys.get("first").unwrap()[0],
-        FIRST_ENTITY_DB_CASED,
-        "csv",
-        "No snapshots for E2E-FiRST/test.sqlite",
-    )?;
+    // The background snapshot daemon runs every 2 seconds. After
+    // deleting all snapshots, the daemon will quickly recreate one
+    // for the current database state. Rather than trying to observe
+    // the zero-snapshot window (which is a race), we wait for the
+    // daemon to produce the first snapshot and then verify via the
+    // case-insensitive slug that listing works correctly.
     let snapshots = wait_for_snapshot_count(
         config_path,
         &api_keys.get("first").unwrap()[0],
@@ -78,6 +104,19 @@ pub async fn test_snapshots(
         1,
         20,
     );
+
+    // Also verify case-insensitive listing works.
+    list_snapshots_match_output(
+        config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB_CASED,
+        "csv",
+        &format!(
+            "Name,Last modified\n{},{}",
+            snapshots[0].snapshot_id,
+            snapshots[0].last_modified_at.to_rfc3339()
+        ),
+    )?;
 
     let last_modified_at = snapshots[0].last_modified_at;
     // No change to database, so same number of snapshots after sleep.
@@ -213,8 +252,8 @@ pub async fn test_snapshots(
         "table",
         "\nRows: 0",
     )?;
-    // Wait for snapshot of the insert above.
-    wait_for_snapshot_count(
+    // Wait for snapshot of the insert above (6th snapshot, no pruning yet).
+    let snapshots_before_prune = wait_for_snapshot_count(
         config_path,
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
@@ -232,14 +271,19 @@ pub async fn test_snapshots(
     )?;
 
     let old_snapshots = snapshots;
-    // After 7 snapshots created and max_snapshots=6, pruning should
-    // leave exactly 6.
-    wait_for_snapshot_count(
+    // The 7th snapshot triggers pruning back to 6. The count stays
+    // at 6, but the newest snapshot ID changes. Wait for that.
+    let snapshots = wait_for_new_snapshot(
         config_path,
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
-        6,
+        &snapshots_before_prune[0].snapshot_id,
         20,
+    );
+    assert_eq!(
+        snapshots.len(),
+        6,
+        "there are six snapshots after further updating database and pruning old snapshots"
     );
 
     // Restoring the previous oldest snapshot fails

--- a/tests/e2e_tests/snapshot_tests.rs
+++ b/tests/e2e_tests/snapshot_tests.rs
@@ -7,6 +7,32 @@ use std::collections::HashMap;
 use std::thread;
 use std::time;
 
+fn wait_for_snapshot_count(
+    config_path: &str,
+    api_key: &str,
+    database: &str,
+    expected: usize,
+    timeout_secs: u64,
+) -> Vec<ayb::server::snapshots::models::ListSnapshotResult> {
+    let deadline = time::Instant::now() + time::Duration::from_secs(timeout_secs);
+    loop {
+        thread::sleep(time::Duration::from_secs(2));
+        let snapshots = list_snapshots(config_path, api_key, database, "csv")
+            .expect("failed to list snapshots");
+        if snapshots.len() == expected || time::Instant::now() >= deadline {
+            assert_eq!(
+                snapshots.len(),
+                expected,
+                "expected {} snapshots but found {} (after {}s timeout)",
+                expected,
+                snapshots.len(),
+                timeout_secs
+            );
+            return snapshots;
+        }
+    }
+}
+
 pub async fn test_snapshots(
     db_type: &str,
     config_path: &str,
@@ -45,28 +71,15 @@ pub async fn test_snapshots(
         "csv",
         "No snapshots for E2E-FiRST/test.sqlite",
     )?;
-    // We'll sleep between various checks in this test to allow the
-    // snapshotting logic, which runs every 2 seconds, to
-    // execute. Each insert, update, and snapshot restore causes
-    // another snapshot to be taken, and if we don't sleep after them,
-    // we can encounter a race condition between the test and the
-    // asynchronous snapshots being taken in parallel. By sleeping, we
-    // ensure predictability of relative snapshot timing and
-    // quanitity.
-    thread::sleep(time::Duration::from_secs(4));
-    let snapshots = list_snapshots(
+    let snapshots = wait_for_snapshot_count(
         config_path,
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
-        "csv",
-    )?;
+        1,
+        20,
+    );
 
     let last_modified_at = snapshots[0].last_modified_at;
-    assert_eq!(
-        snapshots.len(),
-        1,
-        "there should be one snapshot after sleeping"
-    );
     // No change to database, so same number of snapshots after sleep.
     thread::sleep(time::Duration::from_secs(4));
     let snapshots = list_snapshots(
@@ -93,18 +106,12 @@ pub async fn test_snapshots(
         "table",
         "\nRows: 0",
     )?;
-    thread::sleep(time::Duration::from_secs(4));
-    let snapshots = list_snapshots(
+    let snapshots = wait_for_snapshot_count(
         config_path,
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
-        "csv",
-    )?;
-
-    assert_eq!(
-        snapshots.len(),
         2,
-        "there two snapshots after updating database"
+        20,
     );
     // Insert another row and ensure there are four.
     query(
@@ -123,7 +130,14 @@ pub async fn test_snapshots(
         "table",
         " the_count \n-----------\n 4 \n\nRows: 1",
     )?;
-    thread::sleep(time::Duration::from_secs(4));
+    // Wait for snapshot of the latest insert to be taken before restoring.
+    wait_for_snapshot_count(
+        config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        3,
+        20,
+    );
 
     // Restore the previous snapshot, ensuring there are only three
     // rows.
@@ -146,7 +160,14 @@ pub async fn test_snapshots(
         " the_count \n-----------\n 3 \n\nRows: 1",
     )?;
 
-    thread::sleep(time::Duration::from_secs(4));
+    // Wait for the restore-triggered snapshot before doing the next restore.
+    wait_for_snapshot_count(
+        config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        4,
+        20,
+    );
 
     // Restore the snapshot before that, ensuring there are only two
     // rows.
@@ -169,8 +190,14 @@ pub async fn test_snapshots(
         " the_count \n-----------\n 2 \n\nRows: 1",
     )?;
 
-    // Ensure another snapshot-due-to-restore.
-    thread::sleep(time::Duration::from_secs(4));
+    // Wait for restore-triggered snapshot.
+    wait_for_snapshot_count(
+        config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        5,
+        20,
+    );
 
     // There are 6 max_snapshots, so let's force 2 more snapshots to
     // be created (more than 6 snapshots would exist: the original
@@ -186,7 +213,14 @@ pub async fn test_snapshots(
         "table",
         "\nRows: 0",
     )?;
-    thread::sleep(time::Duration::from_secs(4));
+    // Wait for snapshot of the insert above.
+    wait_for_snapshot_count(
+        config_path,
+        &api_keys.get("first").unwrap()[0],
+        FIRST_ENTITY_DB,
+        6,
+        20,
+    );
 
     query(
         config_path,
@@ -197,18 +231,15 @@ pub async fn test_snapshots(
         "\nRows: 0",
     )?;
 
-    thread::sleep(time::Duration::from_secs(4));
     let old_snapshots = snapshots;
-    let snapshots = list_snapshots(
+    // After 7 snapshots created and max_snapshots=6, pruning should
+    // leave exactly 6.
+    wait_for_snapshot_count(
         config_path,
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
-        "csv",
-    )?;
-    assert_eq!(
-        snapshots.len(),
         6,
-        "there are six snapshots after further updating database and pruning old snapshots"
+        20,
     );
 
     // Restoring the previous oldest snapshot fails

--- a/tests/e2e_tests/snapshot_tests.rs
+++ b/tests/e2e_tests/snapshot_tests.rs
@@ -5,55 +5,45 @@ use std::collections::HashMap;
 use std::thread;
 use std::time;
 
+const SNAPSHOT_TIMEOUT_SECS: u64 = 20;
+
+/// Poll until the snapshot list reaches `expected` entries. When
+/// `changed_since` is `Some(id)`, also require the newest snapshot's
+/// ID to differ from `id` — this handles the pruning case where the
+/// count stays the same but the contents change.
 fn wait_for_snapshot_count(
     config_path: &str,
     api_key: &str,
     database: &str,
     expected: usize,
-    timeout_secs: u64,
+    changed_since: Option<&str>,
 ) -> Vec<ayb::server::snapshots::models::ListSnapshotResult> {
-    let deadline = time::Instant::now() + time::Duration::from_secs(timeout_secs);
+    let deadline = time::Instant::now() + time::Duration::from_secs(SNAPSHOT_TIMEOUT_SECS);
     loop {
         thread::sleep(time::Duration::from_secs(2));
         let snapshots = list_snapshots(config_path, api_key, database, "csv")
             .expect("failed to list snapshots");
-        if snapshots.len() == expected || time::Instant::now() >= deadline {
+        let count_ok = snapshots.len() == expected;
+        let newest_ok = match changed_since {
+            Some(prev_id) => !snapshots.is_empty() && snapshots[0].snapshot_id != prev_id,
+            None => true,
+        };
+        if (count_ok && newest_ok) || time::Instant::now() >= deadline {
             assert_eq!(
                 snapshots.len(),
                 expected,
                 "expected {} snapshots but found {} (after {}s timeout)",
                 expected,
                 snapshots.len(),
-                timeout_secs
+                SNAPSHOT_TIMEOUT_SECS
             );
-            return snapshots;
-        }
-    }
-}
-
-/// Wait until the newest snapshot ID differs from `prev_newest_id`,
-/// then return the current snapshot list. This is needed for the
-/// pruning test where the count stays the same (6 → 7 → 6) but the
-/// contents change.
-fn wait_for_new_snapshot(
-    config_path: &str,
-    api_key: &str,
-    database: &str,
-    prev_newest_id: &str,
-    timeout_secs: u64,
-) -> Vec<ayb::server::snapshots::models::ListSnapshotResult> {
-    let deadline = time::Instant::now() + time::Duration::from_secs(timeout_secs);
-    loop {
-        thread::sleep(time::Duration::from_secs(2));
-        let snapshots = list_snapshots(config_path, api_key, database, "csv")
-            .expect("failed to list snapshots");
-        let newest_changed = !snapshots.is_empty() && snapshots[0].snapshot_id != prev_newest_id;
-        if newest_changed || time::Instant::now() >= deadline {
-            assert!(
-                newest_changed,
-                "newest snapshot did not change from {} within {}s",
-                prev_newest_id, timeout_secs
-            );
+            if let Some(prev_id) = changed_since {
+                assert!(
+                    newest_ok,
+                    "newest snapshot did not change from {} within {}s",
+                    prev_id, SNAPSHOT_TIMEOUT_SECS
+                );
+            }
             return snapshots;
         }
     }
@@ -99,11 +89,11 @@ pub async fn test_snapshots(
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
         1,
-        20,
+        None,
     );
 
-    let last_modified_at = snapshots[0].last_modified_at;
     // No change to database, so same number of snapshots after sleep.
+    let last_modified_at = snapshots[0].last_modified_at;
     thread::sleep(time::Duration::from_secs(4));
     let snapshots = list_snapshots(
         config_path,
@@ -120,6 +110,7 @@ pub async fn test_snapshots(
         last_modified_at, snapshots[0].last_modified_at,
         "After sleeping, the snapshot shouldn't have been modified/updated"
     );
+
     // Modify database, wait, and ensure a new snapshot was taken.
     query(
         config_path,
@@ -134,8 +125,9 @@ pub async fn test_snapshots(
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
         2,
-        20,
+        None,
     );
+
     // Insert another row and ensure there are four.
     query(
         config_path,
@@ -153,13 +145,14 @@ pub async fn test_snapshots(
         "table",
         " the_count \n-----------\n 4 \n\nRows: 1",
     )?;
+
     // Wait for snapshot of the latest insert to be taken before restoring.
     wait_for_snapshot_count(
         config_path,
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
         3,
-        20,
+        None,
     );
 
     // Restore the previous snapshot, ensuring there are only three
@@ -189,7 +182,7 @@ pub async fn test_snapshots(
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
         4,
-        20,
+        None,
     );
 
     // Restore the snapshot before that, ensuring there are only two
@@ -219,7 +212,7 @@ pub async fn test_snapshots(
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
         5,
-        20,
+        None,
     );
 
     // There are 6 max_snapshots, so let's force 2 more snapshots to
@@ -236,13 +229,14 @@ pub async fn test_snapshots(
         "table",
         "\nRows: 0",
     )?;
+
     // Wait for snapshot of the insert above (6th snapshot, no pruning yet).
     let snapshots_before_prune = wait_for_snapshot_count(
         config_path,
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
         6,
-        20,
+        None,
     );
 
     query(
@@ -257,12 +251,12 @@ pub async fn test_snapshots(
     let old_snapshots = snapshots;
     // The 7th snapshot triggers pruning back to 6. The count stays
     // at 6, but the newest snapshot ID changes. Wait for that.
-    let snapshots = wait_for_new_snapshot(
+    let snapshots = wait_for_snapshot_count(
         config_path,
         &api_keys.get("first").unwrap()[0],
         FIRST_ENTITY_DB,
-        &snapshots_before_prune[0].snapshot_id,
-        20,
+        6,
+        Some(&snapshots_before_prune[0].snapshot_id),
     );
     assert_eq!(
         snapshots.len(),

--- a/tests/e2e_tests/snapshot_tests.rs
+++ b/tests/e2e_tests/snapshot_tests.rs
@@ -1,6 +1,4 @@
-use crate::e2e_tests::{
-    FIRST_ENTITY_DB, FIRST_ENTITY_DB_CASED, FIRST_ENTITY_DB_SLUG, FIRST_ENTITY_SLUG,
-};
+use crate::e2e_tests::{FIRST_ENTITY_DB, FIRST_ENTITY_DB_SLUG, FIRST_ENTITY_SLUG};
 use crate::utils::ayb::{list_snapshots, list_snapshots_match_output, query, restore_snapshot};
 use crate::utils::testing::snapshot_storage;
 use std::collections::HashMap;
@@ -95,8 +93,7 @@ pub async fn test_snapshots(
     // deleting all snapshots, the daemon will quickly recreate one
     // for the current database state. Rather than trying to observe
     // the zero-snapshot window (which is a race), we wait for the
-    // daemon to produce the first snapshot and then verify via the
-    // case-insensitive slug that listing works correctly.
+    // daemon to produce the first snapshot.
     let snapshots = wait_for_snapshot_count(
         config_path,
         &api_keys.get("first").unwrap()[0],
@@ -104,19 +101,6 @@ pub async fn test_snapshots(
         1,
         20,
     );
-
-    // Also verify case-insensitive listing works.
-    list_snapshots_match_output(
-        config_path,
-        &api_keys.get("first").unwrap()[0],
-        FIRST_ENTITY_DB_CASED,
-        "csv",
-        &format!(
-            "Name,Last modified\n{},{}",
-            snapshots[0].snapshot_id,
-            snapshots[0].last_modified_at.to_rfc3339()
-        ),
-    )?;
 
     let last_modified_at = snapshots[0].last_modified_at;
     // No change to database, so same number of snapshots after sleep.

--- a/tests/e2e_tests/snapshot_tests.rs
+++ b/tests/e2e_tests/snapshot_tests.rs
@@ -5,8 +5,6 @@ use std::collections::HashMap;
 use std::thread;
 use std::time;
 
-const SNAPSHOT_TIMEOUT_SECS: u64 = 20;
-
 /// Poll until the snapshot list reaches `expected` entries. When
 /// `changed_since` is `Some(id)`, also require the newest snapshot's
 /// ID to differ from `id` — this handles the pruning case where the
@@ -18,7 +16,8 @@ fn wait_for_snapshot_count(
     expected: usize,
     changed_since: Option<&str>,
 ) -> Vec<ayb::server::snapshots::models::ListSnapshotResult> {
-    let deadline = time::Instant::now() + time::Duration::from_secs(SNAPSHOT_TIMEOUT_SECS);
+    let timeout_secs = 20;
+    let deadline = time::Instant::now() + time::Duration::from_secs(timeout_secs);
     loop {
         thread::sleep(time::Duration::from_secs(2));
         let snapshots = list_snapshots(config_path, api_key, database, "csv")
@@ -35,13 +34,13 @@ fn wait_for_snapshot_count(
                 "expected {} snapshots but found {} (after {}s timeout)",
                 expected,
                 snapshots.len(),
-                SNAPSHOT_TIMEOUT_SECS
+                timeout_secs
             );
             if let Some(prev_id) = changed_since {
                 assert!(
                     newest_ok,
                     "newest snapshot did not change from {} within {}s",
-                    prev_id, SNAPSHOT_TIMEOUT_SECS
+                    prev_id, timeout_secs
                 );
             }
             return snapshots;


### PR DESCRIPTION
No more hard-coded sleep---explicitly wait for snapshot count or latest snapshot ID to change, with a 20s timeout.