### PR TITLE
Migrate browser E2E tests to playwright-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2 0.6.3",
- "time 0.3.47",
+ "time",
  "tracing",
  "url",
 ]
@@ -553,7 +553,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "thiserror 2.0.12",
- "time 0.3.47",
+ "time",
  "url",
 ]
 
@@ -614,7 +614,7 @@ dependencies = [
  "landlock",
  "lettre",
  "libc",
- "playwright",
+ "playwright-rs",
  "predicates",
  "prefixed-api-key",
  "prettytable-rs",
@@ -632,7 +632,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "tera",
- "time 0.3.47",
+ "time",
  "tokio",
  "tokio-cron-scheduler",
  "toml",
@@ -647,12 +647,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -806,26 +800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,7 +914,7 @@ dependencies = [
  "anstream 0.6.19",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -1097,7 +1071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.47",
+ "time",
  "version_check",
 ]
 
@@ -1271,36 +1245,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1313,19 +1263,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1334,10 +1273,16 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.11",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deranged"
@@ -1364,7 +1309,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1448,20 +1393,20 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
  "dirs-sys 0.3.7",
 ]
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys 0.3.7",
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -1767,6 +1712,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1850,21 +1806,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-channel"
@@ -1939,7 +1880,6 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2010,6 +1950,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
@@ -2248,17 +2194,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -2276,7 +2211,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2312,30 +2247,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -2345,7 +2256,7 @@ dependencies = [
  "futures-util",
  "h2 0.4.11",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2361,7 +2272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2372,26 +2283,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2411,14 +2309,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.5.10",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -2647,7 +2545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -2704,15 +2602,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2909,6 +2798,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3517,27 +3415,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "playwright"
-version = "0.0.20"
+name = "playwright-rs"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45631bc049f37d0cef950da0d60ee35b211ab71180c61aee86880483cf59e28"
+checksum = "3317d37f816d9fbd550ba155a146068575a0c97e5af969f5d0895199344fa0b5"
 dependencies = [
- "base64 0.13.1",
- "chrono",
- "dirs 3.0.2",
- "futures",
- "itertools 0.10.5",
- "log",
- "paste",
- "reqwest 0.11.27",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "glob",
+ "libc",
+ "parking_lot 0.12.4",
+ "playwright-rs-macros",
+ "regex",
  "serde",
  "serde_json",
- "serde_with",
- "strong",
- "thiserror 1.0.69",
+ "tar",
+ "thiserror 2.0.12",
  "tokio",
- "tokio-stream",
+ "tokio-tungstenite",
+ "tracing",
+ "ureq",
+ "url",
  "zip",
+]
+
+[[package]]
+name = "playwright-rs-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dacee5a7346e793f1a4ca72db4b1c0e698c1e21626cdef409e6ec295629c4cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3907,7 +3821,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools 0.14.0",
+ "itertools",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -4038,46 +3952,6 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
@@ -4087,10 +3961,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
- "hyper-tls 0.6.0",
+ "hyper",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
@@ -4101,7 +3975,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -4127,9 +4001,9 @@ dependencies = [
  "futures-core",
  "h2 0.4.11",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -4143,7 +4017,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tower",
@@ -4243,7 +4117,7 @@ dependencies = [
  "sha2 0.10.9",
  "sysinfo",
  "thiserror 2.0.12",
- "time 0.3.47",
+ "time",
  "tokio",
  "tokio-stream",
  "url",
@@ -4284,7 +4158,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4301,15 +4177,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -4564,28 +4431,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4848,21 +4693,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strong"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbe0fc7652d95bcd84f61cd036181b395f329ef45b25169b69a42f72cb6975f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4919,12 +4749,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4959,34 +4783,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.13.0",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -4997,6 +4800,17 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -5107,17 +4921,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
@@ -5183,9 +4986,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5254,7 +5057,20 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -5318,7 +5134,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5334,7 +5150,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -5391,6 +5207,29 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.9.1",
+ "sha1 0.10.6",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -5474,6 +5313,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5491,6 +5359,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5565,12 +5439,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -5759,6 +5627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5936,15 +5813,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5996,21 +5864,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -6058,12 +5911,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6082,12 +5929,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6103,12 +5944,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6142,12 +5977,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6163,12 +5992,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6190,12 +6013,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6211,12 +6028,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6243,16 +6054,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6363,6 +6164,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "y4m"
@@ -6501,23 +6312,41 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.13"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "byteorder",
- "bzip2",
  "crc32fast",
  "flate2",
- "thiserror 1.0.69",
- "time 0.1.45",
+ "indexmap 2.11.4",
+ "memchr",
+ "typed-path",
+ "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ libc = { version = "0.2" }
 assert_cmd = "2.2"
 assert-json-diff = "2.0.2"
 predicates = "3.1.3"
-playwright = "0.0.20"
+playwright-rs = "0.14"
 image = "0.25"
 tempfile = "3.24"
 

--- a/src/server/snapshots/storage.rs
+++ b/src/server/snapshots/storage.rs
@@ -50,7 +50,7 @@ impl SnapshotStorage {
         let mut path_prefix = config.path_prefix.clone();
         if force_path_style {
             bucket = bucket.with_path_style();
-            path_prefix = format!("{}/{}", &config.bucket, path_prefix);
+            path_prefix = format!("{}/{}", config.bucket, path_prefix);
         }
 
         Ok(SnapshotStorage {

--- a/tests/browser_e2e_tests/create_and_query_database.rs
+++ b/tests/browser_e2e_tests/create_and_query_database.rs
@@ -1,5 +1,5 @@
 use crate::utils::browser::BrowserHelpers;
-use playwright::api::{page, Page};
+use playwright_rs::{ClickOptions, FillOptions, Page};
 use std::error::Error;
 use std::fs;
 use std::path::Path;
@@ -13,34 +13,40 @@ pub async fn test_create_and_query_database_flow(
     let expected_title = "Entity 0 - ayb";
     assert_eq!(page.title().await?, expected_title);
 
-    BrowserHelpers::screenshot_compare(&page, "dashboard_before_database_creation", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "dashboard_before_database_creation", &[]).await?;
 
     // Step 2: Click on "Create database" button
-    page.click_builder("button:has-text('Create database')")
-        .timeout(3000.0)
-        .click()
+    page.locator("button:has-text('Create database')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(3000.0).build()))
         .await?;
 
     // Screenshot of the create database form
-    BrowserHelpers::screenshot_compare(&page, "create_database_form", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "create_database_form", &[]).await?;
 
     // Step 3: Fill in database name (using similar name to e2e tests)
-    page.fill_builder("input[name='database_slug']", "test.sqlite")
-        .timeout(1000.0)
-        .fill()
+    page.locator("input[name='database_slug']")
+        .await
+        .first()
+        .fill(
+            "test.sqlite",
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
     // Screenshot of filled form
-    BrowserHelpers::screenshot_compare(&page, "database_form_filled", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "database_form_filled", &[]).await?;
 
     // Step 4: Submit the create database form
-    page.click_builder("button[type='submit']:has-text('Create database')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button[type='submit']:has-text('Create database')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Screenshot after database creation
-    BrowserHelpers::screenshot_compare(&page, "database_created", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "database_created", &[]).await?;
 
     // Step 5: Ensure we're on the database page
     let database_page_title = format!("Explore {}/test.sqlite - ayb", username);
@@ -51,91 +57,114 @@ pub async fn test_create_and_query_database_flow(
     // Step 6: Create the same table as in e2e tests
     let create_table_query = "CREATE TABLE test_table(fname varchar, lname varchar);";
 
-    page.fill_builder("textarea[name='query']", create_table_query)
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            create_table_query,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
     // Screenshot with create table query
-    BrowserHelpers::screenshot_compare(&page, "create_table_query", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "create_table_query", &[]).await?;
 
     // Run the create table query
-    page.click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Screenshot after table creation
-    BrowserHelpers::screenshot_compare(&page, "table_created", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "table_created", &[]).await?;
 
     // Step 7: Insert data
     let insert_query1 =
         "INSERT INTO test_table (fname, lname) VALUES (\"the first\", \"the last\");";
 
     // Clear previous query and enter insert query
-    page.fill_builder("textarea[name='query']", "")
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill("", Some(FillOptions::builder().timeout(1000.0).build()))
         .await?;
 
-    page.fill_builder("textarea[name='query']", insert_query1)
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            insert_query1,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
-    page.click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Insert second row
     let insert_query2 =
         "INSERT INTO test_table (fname, lname) VALUES (\"the first2\", \"the last2\");";
 
-    page.fill_builder("textarea[name='query']", "")
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill("", Some(FillOptions::builder().timeout(1000.0).build()))
         .await?;
 
-    page.fill_builder("textarea[name='query']", insert_query2)
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            insert_query2,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
-    page.click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Screenshot after data insertion
-    BrowserHelpers::screenshot_compare(&page, "data_inserted", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "data_inserted", &[]).await?;
 
     // Step 8: Query the data
     let select_query = "SELECT * FROM test_table;";
 
-    page.fill_builder("textarea[name='query']", "")
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill("", Some(FillOptions::builder().timeout(1000.0).build()))
         .await?;
 
-    page.fill_builder("textarea[name='query']", select_query)
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            select_query,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
     // Screenshot with select query
-    BrowserHelpers::screenshot_compare(&page, "select_query", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "select_query", &[]).await?;
 
-    page.click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Screenshot of query results table
-    BrowserHelpers::screenshot_compare(&page, "query_results", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "query_results", &[]).await?;
 
     // Step 9: Verify the results contain the expected data with exact string matching
-    let query_results = page.inner_text("#query-results", None).await?;
+    let query_results = page.locator("#query-results").await.inner_text().await?;
 
     // Define the expected complete query results content
     let expected_results = "Download CSV\nDownload JSON\nfname\tlname\nthe first\tthe last\nthe first2\tthe last2\n2 rows";
@@ -148,17 +177,13 @@ pub async fn test_create_and_query_database_flow(
     );
 
     // Step 10: Test CSV download functionality
-    let (download_event, _) = tokio::join!(
-        page.expect_event(page::EventType::Download),
-        page.click_builder("button:has-text('Download CSV')")
-            .timeout(3000.0)
-            .click()
-    );
-
-    let download = match download_event? {
-        page::Event::Download(d) => d,
-        _ => return Err("Expected download event".into()),
-    };
+    let download_waiter = page.expect_download(Some(3000.0)).await?;
+    page.locator("button:has-text('Download CSV')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(3000.0).build()))
+        .await?;
+    let download = download_waiter.wait().await?;
 
     // Save download to local folder and verify contents
     let download_path = format!("./test_download_{}.csv", std::process::id());
@@ -179,17 +204,13 @@ pub async fn test_create_and_query_database_flow(
     }
 
     // Step 11: Test JSON download functionality
-    let (download_event, _) = tokio::join!(
-        page.expect_event(page::EventType::Download),
-        page.click_builder("button:has-text('Download JSON')")
-            .timeout(3000.0)
-            .click()
-    );
-
-    let download = match download_event? {
-        page::Event::Download(d) => d,
-        _ => return Err("Expected download event".into()),
-    };
+    let download_waiter = page.expect_download(Some(3000.0)).await?;
+    page.locator("button:has-text('Download JSON')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(3000.0).build()))
+        .await?;
+    let download = download_waiter.wait().await?;
 
     // Save download to local folder and verify contents
     let download_path = format!("./test_download_{}.json", std::process::id());
@@ -213,7 +234,7 @@ pub async fn test_create_and_query_database_flow(
     }
 
     // Final verification screenshot
-    BrowserHelpers::screenshot_compare(&page, "database_test_complete", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "database_test_complete", &[]).await?;
 
     Ok(())
 }

--- a/tests/browser_e2e_tests/entity_profile.rs
+++ b/tests/browser_e2e_tests/entity_profile.rs
@@ -1,6 +1,7 @@
 use crate::utils::browser::BrowserHelpers;
-use playwright::api::Page;
+use playwright_rs::{ClickOptions, FillOptions, GotoOptions, Page};
 use std::error::Error;
+use std::time::Duration;
 
 pub async fn test_entity_profile_flow(page: &Page, username: &str) -> Result<(), Box<dyn Error>> {
     // Step 1: Verify we're on the entity dashboard
@@ -8,86 +9,111 @@ pub async fn test_entity_profile_flow(page: &Page, username: &str) -> Result<(),
     assert_eq!(page.title().await?, expected_title);
 
     // Take initial screenshot of the dashboard
-    BrowserHelpers::screenshot_compare(&page, "entity_dashboard_reference", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "entity_dashboard_reference", &[]).await?;
 
     // Step 2: Enter profile edit mode
-    page.click_builder("button:has-text('Edit profile')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Edit profile')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Screenshot of edit mode activated
-    BrowserHelpers::screenshot_compare(&page, "profile_edit_mode", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "profile_edit_mode", &[]).await?;
 
     // Step 3: Fill in profile fields with test data
-    page.fill_builder("input[name='display_name']", "Entity 0")
-        .timeout(1000.0)
-        .fill()
+    page.locator("input[name='display_name']")
+        .await
+        .first()
+        .fill(
+            "Entity 0",
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
-    page.fill_builder("input[name='description']", "Entity 0 NEW description")
-        .timeout(1000.0)
-        .fill()
+    page.locator("input[name='description']")
+        .await
+        .first()
+        .fill(
+            "Entity 0 NEW description",
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
-    page.fill_builder("input[name='organization']", "Entity 0 organization")
-        .timeout(1000.0)
-        .fill()
+    page.locator("input[name='organization']")
+        .await
+        .first()
+        .fill(
+            "Entity 0 organization",
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
-    page.fill_builder("input[name='location']", "NYC")
-        .timeout(1000.0)
-        .fill()
+    page.locator("input[name='location']")
+        .await
+        .first()
+        .fill("NYC", Some(FillOptions::builder().timeout(1000.0).build()))
         .await?;
 
     // Add first link by clicking the "Add link" button and filling the field
-    page.click_builder("button:has-text('Add link')")
-        .timeout(2000.0)
-        .click()
+    page.locator("button:has-text('Add link')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(2000.0).build()))
         .await?;
 
     // Fill the first link input (should be the only one at this point)
-    page.fill_builder("input[name='links[]']", "http://ayb.host/")
-        .timeout(1000.0)
-        .fill()
+    page.locator("input[name='links[]']")
+        .await
+        .first()
+        .fill(
+            "http://ayb.host/",
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
     // Add a second link
-    page.click_builder("button:has-text('Add link')")
-        .timeout(2000.0)
-        .click()
+    page.locator("button:has-text('Add link')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(2000.0).build()))
         .await?;
 
-    page.fill_builder(
-        "div.link-input-group:nth-child(2) input[name='links[]']",
-        "http://ayb2.host/",
-    )
-    .timeout(3000.0)
-    .fill()
-    .await?;
+    page.locator("div.link-input-group:nth-child(2) input[name='links[]']")
+        .await
+        .first()
+        .fill(
+            "http://ayb2.host/",
+            Some(FillOptions::builder().timeout(3000.0).build()),
+        )
+        .await?;
 
     // Screenshot of filled form
-    BrowserHelpers::screenshot_compare(&page, "profile_form_filled", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "profile_form_filled", &[]).await?;
 
     // Step 4: Save the profile
-    page.click_builder("button:has-text('Save')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Save')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Screenshot after saving
-    BrowserHelpers::screenshot_compare(&page, "profile_saved", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "profile_saved", &[]).await?;
 
     // Step 5: Reload the page to ensure data persistence
-    page.reload_builder().timeout(5000.0).reload().await?;
+    page.reload(Some(
+        GotoOptions::new().timeout(Duration::from_millis(5000)),
+    ))
+    .await?;
 
     // Screenshot after reload to confirm data persisted
-    BrowserHelpers::screenshot_compare(&page, "profile_after_reload", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "profile_after_reload", &[]).await?;
 
     // Step 6: Verify the profile data was saved correctly by checking visible text
 
     // Check display name
-    let page_text = page.inner_text("body", None).await?;
+    let page_text = page.locator("body").await.inner_text().await?;
     assert!(
         page_text.contains("Entity 0"),
         "Display name should be visible after reload"
@@ -122,7 +148,7 @@ pub async fn test_entity_profile_flow(page: &Page, username: &str) -> Result<(),
     );
 
     // Final verification screenshot
-    BrowserHelpers::screenshot_compare(&page, "profile_verification_complete", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "profile_verification_complete", &[]).await?;
 
     Ok(())
 }

--- a/tests/browser_e2e_tests/oauth_flow.rs
+++ b/tests/browser_e2e_tests/oauth_flow.rs
@@ -1,6 +1,6 @@
 use crate::utils::browser::BrowserHelpers;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use playwright::api::Page;
+use playwright_rs::{ClickOptions, Page, WaitForOptions};
 use prefixed_api_key::rand::{self, Rng};
 use sha2::{Digest, Sha256};
 use std::error::Error;
@@ -67,11 +67,12 @@ async fn complete_oauth_flow(
         urlencoding::encode(&app_name)
     );
 
-    page.goto_builder(&authorize_url).goto().await?;
+    page.goto(&authorize_url, None).await?;
 
-    page.wait_for_selector_builder("#database-select")
-        .timeout(5000.0)
-        .wait_for_selector()
+    page.locator("#database-select")
+        .await
+        .first()
+        .wait_for(Some(WaitForOptions::builder().timeout(5000.0).build()))
         .await?;
 
     BrowserHelpers::screenshot_compare(
@@ -96,7 +97,7 @@ async fn complete_oauth_flow(
         "#,
         db = database_path
     );
-    page.evaluate::<serde_json::Value, serde_json::Value>(&select_script, serde_json::Value::Null)
+    page.evaluate::<serde_json::Value, serde_json::Value>(&select_script, None)
         .await?;
 
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -108,14 +109,15 @@ async fn complete_oauth_flow(
     )
     .await?;
 
-    page.click_builder("#authorize-btn")
-        .timeout(5000.0)
-        .click()
+    page.locator("#authorize-btn")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    let current_url = page.url()?;
+    let current_url = page.url();
     let url = url::Url::parse(&current_url)?;
 
     let code = url
@@ -361,11 +363,12 @@ pub async fn test_oauth_deny_flow(
         urlencoding::encode("Deny Test App")
     );
 
-    page.goto_builder(&authorize_url).goto().await?;
+    page.goto(&authorize_url, None).await?;
 
-    page.wait_for_selector_builder("#database-select")
-        .timeout(5000.0)
-        .wait_for_selector()
+    page.locator("#database-select")
+        .await
+        .first()
+        .wait_for(Some(WaitForOptions::builder().timeout(5000.0).build()))
         .await?;
 
     let database_path = format!("{}/test.sqlite", username);
@@ -379,19 +382,20 @@ pub async fn test_oauth_deny_flow(
         "#,
         db = database_path
     );
-    page.evaluate::<serde_json::Value, serde_json::Value>(&select_script, serde_json::Value::Null)
+    page.evaluate::<serde_json::Value, serde_json::Value>(&select_script, None)
         .await?;
 
     BrowserHelpers::screenshot_compare(page, "oauth_before_deny", &[]).await?;
 
-    page.click_builder("button[value='deny']")
-        .timeout(5000.0)
-        .click()
+    page.locator("button[value='deny']")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    let current_url = page.url()?;
+    let current_url = page.url();
 
     let url = url::Url::parse(&current_url)?;
     let error = url

--- a/tests/browser_e2e_tests/permissions.rs
+++ b/tests/browser_e2e_tests/permissions.rs
@@ -1,7 +1,8 @@
 use crate::browser_e2e_tests::test_registration_flow;
 use crate::utils::browser::BrowserHelpers;
-use playwright::api::Page;
+use playwright_rs::{BrowserContext, ClickOptions, FillOptions, GotoOptions, Page};
 use std::error::Error;
+use std::time::Duration;
 
 pub struct UserBrowserProfile {
     pub username: String,
@@ -10,7 +11,7 @@ pub struct UserBrowserProfile {
 
 /// Register multiple users in separate browser contexts
 pub async fn register_multiple_users(
-    contexts_and_pages: Vec<(playwright::api::BrowserContext, Page)>,
+    contexts_and_pages: Vec<(BrowserContext, Page)>,
     base_url: &str,
     test_type: &str,
 ) -> Result<Vec<UserBrowserProfile>, Box<dyn Error>> {
@@ -51,16 +52,21 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // Create database
     user_a
         .page
-        .click_builder("button:has-text('Create database')")
-        .timeout(3000.0)
-        .click()
+        .locator("button:has-text('Create database')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(3000.0).build()))
         .await?;
 
     user_a
         .page
-        .fill_builder("input[name='database_slug']", "shared_test.sqlite")
-        .timeout(1000.0)
-        .fill()
+        .locator("input[name='database_slug']")
+        .await
+        .first()
+        .fill(
+            "shared_test.sqlite",
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
     // Database is created as private by default
@@ -68,9 +74,10 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
 
     user_a
         .page
-        .click_builder("button[type='submit']:has-text('Create database')")
-        .timeout(5000.0)
-        .click()
+        .locator("button[type='submit']:has-text('Create database')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_a.page, "userA_database_created", &[]).await?;
@@ -80,16 +87,21 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
 
     user_a
         .page
-        .fill_builder("textarea[name='query']", create_table_query)
-        .timeout(1000.0)
-        .fill()
+        .locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            create_table_query,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
     user_a
         .page
-        .click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+        .locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_a.page, "userA_table_created", &[]).await?;
@@ -97,12 +109,13 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // Step 5: Users B and C should not see User A's private database
     user_b
         .page
-        .goto_builder(&format!("{}/{}", base_url, user_a.username))
-        .timeout(5000.0)
-        .goto()
+        .goto(
+            &format!("{}/{}", base_url, user_a.username),
+            Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+        )
         .await?;
 
-    let page_content_b = user_b.page.inner_text("body", None).await?;
+    let page_content_b = user_b.page.locator("body").await.inner_text().await?;
     let can_see_db_b = page_content_b.contains("shared_test.sqlite");
     assert!(
         !can_see_db_b,
@@ -112,12 +125,13 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
 
     user_c
         .page
-        .goto_builder(&format!("{}/{}", base_url, user_a.username))
-        .timeout(5000.0)
-        .goto()
+        .goto(
+            &format!("{}/{}", base_url, user_a.username),
+            Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+        )
         .await?;
 
-    let page_content_c = user_c.page.inner_text("body", None).await?;
+    let page_content_c = user_c.page.locator("body").await.inner_text().await?;
     let can_see_db_c = page_content_c.contains("shared_test.sqlite");
     assert!(
         !can_see_db_c,
@@ -129,19 +143,18 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // User A navigates to database and clicks sharing tab
     user_a
         .page
-        .goto_builder(&format!(
-            "{}/{}/shared_test.sqlite",
-            base_url, user_a.username
-        ))
-        .timeout(5000.0)
-        .goto()
+        .goto(
+            &format!("{}/{}/shared_test.sqlite", base_url, user_a.username),
+            Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+        )
         .await?;
 
     user_a
         .page
-        .click_builder("a[href='#sharing']")
-        .timeout(5000.0)
-        .click()
+        .locator("a[href='#sharing']")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_a.page, "userA_sharing_tab", &[]).await?;
@@ -149,16 +162,18 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // Set public sharing to read-only
     user_a
         .page
-        .click_builder("button[data-value='read-only']")
-        .timeout(3000.0)
-        .click()
+        .locator("button[data-value='read-only']")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(3000.0).build()))
         .await?;
 
     user_a
         .page
-        .click_builder("#update-public-sharing-btn")
-        .timeout(5000.0)
-        .click()
+        .locator("#update-public-sharing-btn")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_a.page, "userA_set_public_readonly", &[]).await?;
@@ -166,12 +181,10 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // Users B and C should now be able to access the database
     user_b
         .page
-        .goto_builder(&format!(
-            "{}/{}/shared_test.sqlite",
-            base_url, user_a.username
-        ))
-        .timeout(5000.0)
-        .goto()
+        .goto(
+            &format!("{}/{}/shared_test.sqlite", base_url, user_a.username),
+            Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+        )
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_b.page, "userB_can_access_readonly", &[]).await?;
@@ -179,22 +192,32 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // User B can run read-only query
     user_b
         .page
-        .fill_builder("textarea[name='query']", "SELECT COUNT(*) FROM test_table;")
-        .timeout(1000.0)
-        .fill()
+        .locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            "SELECT COUNT(*) FROM test_table;",
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
     user_b
         .page
-        .click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+        .locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_b.page, "userB_readonly_query_success", &[]).await?;
 
     // Verify User B can see the count result (should be 0 since no data inserted yet)
-    let query_results_b_count = user_b.page.inner_text("#query-results", None).await?;
+    let query_results_b_count = user_b
+        .page
+        .locator("#query-results")
+        .await
+        .inner_text()
+        .await?;
     assert!(
         query_results_b_count.contains("0"),
         "User B should see count of 0 rows in empty table"
@@ -203,25 +226,32 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // User B cannot run insert query (should fail)
     user_b
         .page
-        .fill_builder(
-            "textarea[name='query']",
+        .locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
             "INSERT INTO test_table (fname, lname) VALUES ('unauthorized', 'insert');",
+            Some(FillOptions::builder().timeout(1000.0).build()),
         )
-        .timeout(1000.0)
-        .fill()
         .await?;
 
     user_b
         .page
-        .click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+        .locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_b.page, "userB_insert_query_failed", &[]).await?;
 
     // Verify the error message indicates read-only access
-    let query_results_b = user_b.page.inner_text("#query-results", None).await?;
+    let query_results_b = user_b
+        .page
+        .locator("#query-results")
+        .await
+        .inner_text()
+        .await?;
     assert!(
         query_results_b.contains("Attempted to write to database while in read-only mode"),
         "User B should get the specific read-only error when trying to insert"
@@ -230,12 +260,10 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // User C should also be able to access the database now
     user_c
         .page
-        .goto_builder(&format!(
-            "{}/{}/shared_test.sqlite",
-            base_url, user_a.username
-        ))
-        .timeout(5000.0)
-        .goto()
+        .goto(
+            &format!("{}/{}/shared_test.sqlite", base_url, user_a.username),
+            Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+        )
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_c.page, "userC_can_access_readonly", &[]).await?;
@@ -246,33 +274,34 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // User A sets database back to private
     user_a
         .page
-        .goto_builder(&format!(
-            "{}/{}/shared_test.sqlite",
-            base_url, user_a.username
-        ))
-        .timeout(5000.0)
-        .goto()
+        .goto(
+            &format!("{}/{}/shared_test.sqlite", base_url, user_a.username),
+            Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+        )
         .await?;
 
     user_a
         .page
-        .click_builder("a[href='#sharing']")
-        .timeout(5000.0)
-        .click()
+        .locator("a[href='#sharing']")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     user_a
         .page
-        .click_builder("button[data-value='no-access']")
-        .timeout(3000.0)
-        .click()
+        .locator("button[data-value='no-access']")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(3000.0).build()))
         .await?;
 
     user_a
         .page
-        .click_builder("#update-public-sharing-btn")
-        .timeout(5000.0)
-        .click()
+        .locator("#update-public-sharing-btn")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_a.page, "userA_set_back_to_private", &[]).await?;
@@ -280,23 +309,29 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // User A shares specifically with User B
     user_a
         .page
-        .fill_builder("#share-entity", &user_b.username)
-        .timeout(1000.0)
-        .fill()
+        .locator("#share-entity")
+        .await
+        .first()
+        .fill(
+            &user_b.username,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
     user_a
         .page
-        .click_builder("#entity-sharing-form button[data-value='read-only']")
-        .timeout(3000.0)
-        .click()
+        .locator("#entity-sharing-form button[data-value='read-only']")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(3000.0).build()))
         .await?;
 
     user_a
         .page
-        .click_builder("#share-entity-btn")
-        .timeout(5000.0)
-        .click()
+        .locator("#share-entity-btn")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Sleep a little bit so new sharing table can be retrieved/rendered.
@@ -307,12 +342,10 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // User B should now be able to access the database
     user_b
         .page
-        .goto_builder(&format!(
-            "{}/{}/shared_test.sqlite",
-            base_url, user_a.username
-        ))
-        .timeout(5000.0)
-        .goto()
+        .goto(
+            &format!("{}/{}/shared_test.sqlite", base_url, user_a.username),
+            Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+        )
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_b.page, "userB_specific_access_granted", &[]).await?;
@@ -320,22 +353,32 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // User B can run read-only query
     user_b
         .page
-        .fill_builder("textarea[name='query']", "SELECT COUNT(*) FROM test_table;")
-        .timeout(1000.0)
-        .fill()
+        .locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            "SELECT COUNT(*) FROM test_table;",
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
     user_b
         .page
-        .click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+        .locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     BrowserHelpers::screenshot_compare(&user_b.page, "userB_specific_query_success", &[]).await?;
 
     // Verify User B can see the count result (should still be 0)
-    let query_results_b_specific = user_b.page.inner_text("#query-results", None).await?;
+    let query_results_b_specific = user_b
+        .page
+        .locator("#query-results")
+        .await
+        .inner_text()
+        .await?;
     assert!(
         query_results_b_specific.contains("0"),
         "User B should see count of 0 rows when specifically shared"
@@ -344,15 +387,13 @@ pub async fn test_permissions_flow(base_url: &str, test_type: &str) -> Result<()
     // User C should still not be able to access the database
     user_c
         .page
-        .goto_builder(&format!(
-            "{}/{}/shared_test.sqlite",
-            base_url, user_a.username
-        ))
-        .timeout(5000.0)
-        .goto()
+        .goto(
+            &format!("{}/{}/shared_test.sqlite", base_url, user_a.username),
+            Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+        )
         .await?;
 
-    let page_content_c_final = user_c.page.inner_text("body", None).await?;
+    let page_content_c_final = user_c.page.locator("body").await.inner_text().await?;
     let can_see_db_c_final = page_content_c_final.contains("shared_test.sqlite")
         || page_content_c_final.contains("Query");
     assert!(

--- a/tests/browser_e2e_tests/registration_tests.rs
+++ b/tests/browser_e2e_tests/registration_tests.rs
@@ -1,7 +1,8 @@
 use crate::utils::browser::BrowserHelpers;
 use crate::utils::email::{extract_token_from_emails, get_emails_for_recipient};
-use playwright::api::Page;
+use playwright_rs::{ClickOptions, FillOptions, GotoOptions, Page};
 use std::error::Error;
+use std::time::Duration;
 
 pub async fn test_registration_flow(
     page: &Page,
@@ -9,16 +10,17 @@ pub async fn test_registration_flow(
     test_type: &str,
 ) -> Result<String, Box<dyn Error>> {
     // Step 1: Navigate to registration page
-    page.goto_builder(&format!("{}/register", base_url))
-        .timeout(5000.0)
-        .goto()
-        .await?;
+    page.goto(
+        &format!("{}/register", base_url),
+        Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+    )
+    .await?;
 
     // Verify page title
     assert_eq!(page.title().await?, "Create account - ayb");
 
     // Screenshot comparison of registration page
-    BrowserHelpers::screenshot_compare(&page, "registration_page", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "registration_page", &[]).await?;
 
     // Step 2: Fill registration form with unique username
     let timestamp = std::time::SystemTime::now()
@@ -28,26 +30,32 @@ pub async fn test_registration_flow(
     let username = format!("testuser_{}", timestamp);
     let email = format!("{}@example.com", username);
 
-    page.fill_builder("input[name='username']", &username)
-        .timeout(1000.0)
-        .fill()
+    page.locator("input[name='username']")
+        .await
+        .first()
+        .fill(
+            &username,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
-    page.fill_builder("input[name='email']", &email)
-        .timeout(1000.0)
-        .fill()
+    page.locator("input[name='email']")
+        .await
+        .first()
+        .fill(&email, Some(FillOptions::builder().timeout(1000.0).build()))
         .await?;
 
     // Screenshot of filled form
-    BrowserHelpers::screenshot_compare(&page, "registration_form_filled", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "registration_form_filled", &[]).await?;
 
     // Step 3: Submit form
-    page.click_builder("button:has-text('Create account')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Create account')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Screenshot comparison of check email page
-    BrowserHelpers::screenshot_compare(&page, "check_email_page", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "check_email_page", &[]).await?;
 
     // Step 4: Verify we're on the check email page
     assert_eq!(page.title().await?, "Check email - ayb");
@@ -61,13 +69,14 @@ pub async fn test_registration_flow(
     let confirmation_url = format!("{}/confirm/{}", base_url, confirmation_token);
 
     // Step 6: Navigate to confirmation link
-    page.goto_builder(&confirmation_url)
-        .timeout(5000.0)
-        .goto()
-        .await?;
+    page.goto(
+        &confirmation_url,
+        Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+    )
+    .await?;
 
     // Screenshot comparison of user dashboard
-    BrowserHelpers::screenshot_compare(&page, "user_dashboard", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "user_dashboard", &[]).await?;
 
     // Step 7: Verify we're now on the authenticated user dashboard
     let expected_title = format!("{} - ayb", username);

--- a/tests/browser_e2e_tests/snapshots.rs
+++ b/tests/browser_e2e_tests/snapshots.rs
@@ -1,6 +1,7 @@
 use crate::utils::browser::BrowserHelpers;
-use playwright::api::Page;
+use playwright_rs::{ClickOptions, FillOptions, GotoOptions, Page, WaitForOptions};
 use std::error::Error;
+use std::time::Duration;
 
 pub async fn test_snapshots_flow(
     page: &Page,
@@ -11,35 +12,41 @@ pub async fn test_snapshots_flow(
     let database_page_title = format!("Explore {}/test.sqlite - ayb", username);
     let database_url = format!("{}/{}/test.sqlite", base_url, username);
 
-    page.goto_builder(&database_url)
-        .timeout(5000.0)
-        .goto()
-        .await?;
+    page.goto(
+        &database_url,
+        Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+    )
+    .await?;
 
     // Verify we're on the correct database page
     assert_eq!(page.title().await?, database_page_title);
 
-    BrowserHelpers::screenshot_compare(&page, "snapshots_database_page_start", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_database_page_start", &[]).await?;
 
     // Step 2: Query to check existing row count (should be 2 from create_and_query_database.rs)
     let count_query = "SELECT COUNT(*) FROM test_table;";
 
-    page.fill_builder("textarea[name='query']", count_query)
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            count_query,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
-    BrowserHelpers::screenshot_compare(&page, "snapshots_count_query", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_count_query", &[]).await?;
 
-    page.click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
-    BrowserHelpers::screenshot_compare(&page, "snapshots_initial_count", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_initial_count", &[]).await?;
 
     // Verify we have 2 rows initially
-    let page_text = page.inner_text("#query-results", None).await?;
+    let page_text = page.locator("#query-results").await.inner_text().await?;
     assert!(page_text.contains("2"), "Initial count should show 2 rows");
 
     // Step 3: Wait for automatic snapshot to be created (snapshots are auto-created after DB changes)
@@ -49,41 +56,52 @@ pub async fn test_snapshots_flow(
     // Step 4: Insert a new row
     let insert_query = "INSERT INTO test_table (fname, lname) VALUES (\"snapshot\", \"test\");";
 
-    page.fill_builder("textarea[name='query']", "")
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill("", Some(FillOptions::builder().timeout(1000.0).build()))
         .await?;
 
-    page.fill_builder("textarea[name='query']", insert_query)
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            insert_query,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
-    BrowserHelpers::screenshot_compare(&page, "snapshots_insert_query", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_insert_query", &[]).await?;
 
-    page.click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
-    BrowserHelpers::screenshot_compare(&page, "snapshots_row_inserted", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_row_inserted", &[]).await?;
 
     // Step 5: Verify we now have 3 rows
-    page.fill_builder("textarea[name='query']", count_query)
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            count_query,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
-    page.click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Screenshot immediately after query execution (following create_and_query_database pattern)
-    BrowserHelpers::screenshot_compare(&page, "snapshots_count_after_insert", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_count_after_insert", &[]).await?;
 
     // Now read the results from the specific query results element
-    let query_results = page.inner_text("#query-results", None).await?;
+    let query_results = page.locator("#query-results").await.inner_text().await?;
     assert!(
         query_results.contains("3"),
         "Count after insert should show 3 rows"
@@ -94,59 +112,69 @@ pub async fn test_snapshots_flow(
 
     // Step 7: Click the Snapshots tab to see available snapshots
     // This triggers the proper tab switching and AJAX loading of snapshots
-    page.click_builder("a[href='#snapshots']")
-        .timeout(5000.0)
-        .click()
+    page.locator("a[href='#snapshots']")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
-    BrowserHelpers::screenshot_compare(&page, "snapshots_list_page", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_list_page", &[]).await?;
 
     // Step 8: Click the restore button for the SECOND snapshot (older one with 2 rows)
     // Snapshots are sorted newest-first, so we need the second table row's button
-    page.click_builder("tbody tr:nth-child(2) button[title='Restore from this snapshot']")
-        .timeout(5000.0)
-        .click()
+    page.locator("tbody tr:nth-child(2) button[title='Restore from this snapshot']")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Extra delay for modal animation to complete
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-    BrowserHelpers::screenshot_compare(&page, "snapshots_confirmation_modal", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_confirmation_modal", &[]).await?;
 
     // Step 9: Wait for the actual restore button to be clickable and click it
-    page.wait_for_selector_builder("#confirm-restore-btn")
-        .timeout(15000.0)
-        .wait_for_selector()
+    page.locator("#confirm-restore-btn")
+        .await
+        .first()
+        .wait_for(Some(WaitForOptions::builder().timeout(15000.0).build()))
         .await?;
 
-    page.click_builder("#confirm-restore-btn")
-        .timeout(15000.0)
-        .click()
+    page.locator("#confirm-restore-btn")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(15000.0).build()))
         .await?;
 
-    BrowserHelpers::screenshot_compare(&page, "snapshots_restored", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_restored", &[]).await?;
 
     // Step 10: Navigate back to database page to verify restoration
     let database_url = format!("{}/{}/test.sqlite", base_url, username);
-    page.goto_builder(&database_url)
-        .timeout(5000.0)
-        .goto()
-        .await?;
+    page.goto(
+        &database_url,
+        Some(GotoOptions::new().timeout(Duration::from_millis(5000))),
+    )
+    .await?;
 
     // Step 11: Verify we're back to 2 rows (one less than the 3 we had)
-    page.fill_builder("textarea[name='query']", count_query)
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            count_query,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
-    page.click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
-    BrowserHelpers::screenshot_compare(&page, "snapshots_final_count", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_final_count", &[]).await?;
 
-    let page_text_after_restore = page.inner_text("#query-results", None).await?;
+    let page_text_after_restore = page.locator("#query-results").await.inner_text().await?;
     assert!(
         page_text_after_restore.contains("2"),
         "Count after snapshot restore should show 2 rows (one less than before)"
@@ -155,19 +183,24 @@ pub async fn test_snapshots_flow(
     // Step 12: Verify the inserted row is gone
     let select_query = "SELECT * FROM test_table;";
 
-    page.fill_builder("textarea[name='query']", select_query)
-        .timeout(1000.0)
-        .fill()
+    page.locator("textarea[name='query']")
+        .await
+        .first()
+        .fill(
+            select_query,
+            Some(FillOptions::builder().timeout(1000.0).build()),
+        )
         .await?;
 
-    page.click_builder("button:has-text('Run query')")
-        .timeout(5000.0)
-        .click()
+    page.locator("button:has-text('Run query')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
-    BrowserHelpers::screenshot_compare(&page, "snapshots_test_complete", &[]).await?;
+    BrowserHelpers::screenshot_compare(page, "snapshots_test_complete", &[]).await?;
 
-    let final_page_text = page.inner_text("#query-results", None).await?;
+    let final_page_text = page.locator("#query-results").await.inner_text().await?;
     assert!(
         !final_page_text.contains("snapshot"),
         "The inserted row with 'snapshot' should be gone after restore"

--- a/tests/browser_e2e_tests/token_management.rs
+++ b/tests/browser_e2e_tests/token_management.rs
@@ -1,5 +1,5 @@
 use crate::utils::browser::BrowserHelpers;
-use playwright::api::Page;
+use playwright_rs::{ClickOptions, Page, WaitForOptions, WaitForState};
 use std::error::Error;
 
 /// Test the token management UI flow.
@@ -35,25 +35,26 @@ pub async fn test_token_management_flow(
 
     // Step 1: Navigate to the user's profile page first (previous test may
     // have left us on a non-ayb page like the OAuth callback URL).
-    page.goto_builder(&format!("{}/{}", base_url, username))
-        .goto()
+    page.goto(&format!("{}/{}", base_url, username), None)
         .await?;
 
     // Navigate to the tokens page via the dropdown menu
-    page.click_builder(&format!("a:has-text('{}')", username))
-        .timeout(5000.0)
-        .click()
+    page.locator(&format!("a:has-text('{}')", username))
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     BrowserHelpers::screenshot_compare(page, "tokens_dropdown_menu", &[]).await?;
 
-    page.click_builder("a:has-text('Tokens')")
-        .timeout(5000.0)
-        .click()
+    page.locator("a:has-text('Tokens')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Step 2: Verify we're on the tokens page
-    let page_url = page.url()?;
+    let page_url = page.url();
     assert!(
         page_url.contains("/settings/tokens"),
         "Should be on the tokens page, got: {}",
@@ -63,7 +64,7 @@ pub async fn test_token_management_flow(
     BrowserHelpers::screenshot_compare(page, "tokens_page_initial", &[]).await?;
 
     // Step 3: Verify the page content
-    let page_text = page.inner_text("body", None).await?;
+    let page_text = page.locator("body").await.inner_text().await?;
     assert!(
         page_text.contains("API Tokens") || page_text.contains("Short token"),
         "Tokens page should show token-related content"
@@ -97,16 +98,22 @@ pub async fn test_token_management_flow(
     BrowserHelpers::screenshot_compare(page, "tokens_page_with_revoke_buttons", &[]).await?;
 
     // Step 7: Revoke the read-only OAuth token by finding its row via the app name
-    page.click_builder("tr:has-text('Test OAuth App (read-only)') button:has-text('Revoke')")
-        .timeout(5000.0)
-        .click()
+    page.locator("tr:has-text('Test OAuth App (read-only)') button:has-text('Revoke')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     // Wait for the modal to appear
-    page.wait_for_selector_builder("#revoke-token-modal")
-        .state(playwright::api::frame::FrameState::Visible)
-        .timeout(5000.0)
-        .wait_for_selector()
+    page.locator("#revoke-token-modal")
+        .await
+        .first()
+        .wait_for(Some(
+            WaitForOptions::builder()
+                .state(WaitForState::Visible)
+                .timeout(5000.0)
+                .build(),
+        ))
         .await?;
 
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
@@ -114,9 +121,10 @@ pub async fn test_token_management_flow(
     BrowserHelpers::screenshot_compare(page, "tokens_revoke_modal", &[]).await?;
 
     // Click the confirm button
-    page.click_builder("#confirm-revoke-btn")
-        .timeout(5000.0)
-        .click()
+    page.locator("#confirm-revoke-btn")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
@@ -124,17 +132,18 @@ pub async fn test_token_management_flow(
     BrowserHelpers::screenshot_compare(page, "tokens_page_after_revoke", &[]).await?;
 
     // Verify the revocation message appears
-    let page_text = page.inner_text("body", None).await?;
+    let page_text = page.locator("body").await.inner_text().await?;
     assert!(
         page_text.contains("revoked successfully"),
         "Should show revocation success message"
     );
 
     // Reload and verify token count decreased
-    page.reload_builder().reload().await?;
-    page.wait_for_selector_builder("table")
-        .timeout(5000.0)
-        .wait_for_selector()
+    page.reload(None).await?;
+    page.locator("table")
+        .await
+        .first()
+        .wait_for(Some(WaitForOptions::builder().timeout(5000.0).build()))
         .await?;
 
     let rows_after_reload = page.query_selector_all("table tbody tr").await?;
@@ -171,17 +180,19 @@ pub async fn test_token_management_flow(
     println!("Confirmed: revoked OAuth token no longer works");
 
     // Step 9: Navigate back to profile
-    page.click_builder(&format!("a:has-text('{}')", username))
-        .timeout(5000.0)
-        .click()
+    page.locator(&format!("a:has-text('{}')", username))
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
-    page.click_builder("a:has-text('Profile')")
-        .timeout(5000.0)
-        .click()
+    page.locator("a:has-text('Profile')")
+        .await
+        .first()
+        .click(Some(ClickOptions::builder().timeout(5000.0).build()))
         .await?;
 
-    let profile_url = page.url()?;
+    let profile_url = page.url();
     assert!(
         profile_url.ends_with(&format!("/{}", username))
             || profile_url.contains(&format!("/{}/", username)),

--- a/tests/set_up_e2e_env.sh
+++ b/tests/set_up_e2e_env.sh
@@ -7,7 +7,10 @@ fi
 source tests/test-env/bin/activate
 
 # Install requirements
-pip install awscli playwright
+# Pin playwright to the version bundled by the playwright-rs crate's driver
+# (see PLAYWRIGHT_VERSION in the crate's build.rs) so the Chromium revision
+# installed here matches the driver the tests drive it with.
+pip install awscli "playwright==1.60.0"
 
 # Try to install Playwright browsers, but don't fail if unsupported
 echo "Installing Playwright browsers..."

--- a/tests/utils/browser.rs
+++ b/tests/utils/browser.rs
@@ -1,9 +1,9 @@
 use image::GenericImageView;
-use playwright::{
-    api::{BrowserContext, Page},
-    Playwright,
+use playwright_rs::{
+    Browser, BrowserContext, BrowserContextOptions, BrowserType, LaunchOptions, Page, Playwright,
+    ScreenshotOptions,
 };
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 static SCREENSHOT_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -15,7 +15,7 @@ impl BrowserHelpers {
     pub async fn set_up_browser(
         user_count: usize,
     ) -> Result<(Playwright, Vec<(BrowserContext, Page)>), Box<dyn std::error::Error>> {
-        let playwright = Playwright::initialize().await?;
+        let playwright = Playwright::launch().await?;
 
         // Check for BROWSER_VISIBLE environment variable to run in non-headless mode
         let headless = std::env::var("BROWSER_VISIBLE").is_err();
@@ -28,15 +28,17 @@ impl BrowserHelpers {
         }
 
         let chromium = playwright.chromium();
-        let browser = Self::try_launch_browser(&chromium, headless).await?;
+        let browser = Self::try_launch_browser(chromium, headless).await?;
 
         let mut contexts_and_pages = Vec::new();
 
         for i in 0..user_count {
             let context = browser
-                .context_builder()
-                .accept_downloads(true)
-                .build()
+                .new_context_with_options(
+                    BrowserContextOptions::builder()
+                        .accept_downloads(true)
+                        .build(),
+                )
                 .await?;
             let page = context.new_page().await?;
 
@@ -51,11 +53,14 @@ impl BrowserHelpers {
     }
 
     async fn try_launch_browser(
-        chromium: &playwright::api::BrowserType,
+        chromium: &BrowserType,
         headless: bool,
-    ) -> Result<playwright::api::Browser, Box<dyn std::error::Error>> {
+    ) -> Result<Browser, Box<dyn std::error::Error>> {
         // Strategy 1: Try Playwright-installed browser first
-        match chromium.launcher().headless(headless).launch().await {
+        match chromium
+            .launch_with_options(LaunchOptions::new().headless(headless))
+            .await
+        {
             Ok(browser) => return Ok(browser),
             Err(_) => println!(
                 "Preinstalled Playwright not available on this platform, trying fallbacks..."
@@ -83,10 +88,11 @@ impl BrowserHelpers {
             if std::path::Path::new(path).exists() {
                 println!("Trying system browser at: {}", path);
                 match chromium
-                    .launcher()
-                    .headless(headless)
-                    .executable(std::path::Path::new(path))
-                    .launch()
+                    .launch_with_options(
+                        LaunchOptions::new()
+                            .headless(headless)
+                            .executable_path(path.to_string()),
+                    )
                     .await
                 {
                     Ok(browser) => return Ok(browser),
@@ -147,7 +153,7 @@ impl BrowserHelpers {
                 selector
             );
             if let Err(e) = page
-                .evaluate::<serde_json::Value, serde_json::Value>(&script, serde_json::Value::Null)
+                .evaluate::<serde_json::Value, serde_json::Value>(&script, None)
                 .await
             {
                 println!("Warning: Could not grey out selector '{}': {}", selector, e);
@@ -158,11 +164,11 @@ impl BrowserHelpers {
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
 
         // Take current screenshot
-        page.screenshot_builder()
-            .path(PathBuf::from(&current_path))
-            .full_page(true)
-            .screenshot()
-            .await?;
+        page.screenshot_to_file(
+            Path::new(&current_path),
+            Some(ScreenshotOptions::builder().full_page(true).build()),
+        )
+        .await?;
 
         // If no reference exists, save current as reference
         if !Path::new(&reference_path).exists() {


### PR DESCRIPTION
The abandoned `playwright` 0.0.20 crate downloaded its Node driver from
Microsoft's retired azureedge CDN, which now 404s and breaks
`Playwright::initialize()` in CI. Switch to the maintained `playwright-rs`
0.14 fork, whose driver is assembled at build time from the npm registry
(no dependency on any retired CDN).

Rewrite the shared browser helper and all call-sites against the new API:

- `Playwright::launch()` instead of `initialize()`.
- Launch via `launch_with_options(LaunchOptions::new()...)`, preserving the
  headless/BROWSER_VISIBLE toggle and the system-Chrome executable fallback
  chain (now `executable_path`).
- Contexts via `new_context_with_options(BrowserContextOptions::builder()
  .accept_downloads(true).build())`.
- Screenshots via `screenshot_to_file` with `ScreenshotOptions`, keeping the
  reference-PNG image-diff logic unchanged.
- Page actions move to auto-waiting locators: `page.locator(sel).await
  .first()...` for click/fill/wait_for (`.first()` preserves the old
  non-strict first-match semantics), with `ClickOptions`/`FillOptions`/
  `WaitForOptions`/`WaitForState` carrying the timeouts.
- `goto`/`reload` take `GotoOptions`; `page.url()` now returns `String`.
- CSV/JSON download capture uses `expect_download` + `EventWaiter::wait`.

Pin the Python `playwright` install in set_up_e2e_env.sh to 1.60.0 so the
installed Chromium revision matches the driver the crate bundles.

Also includes a one-line, unrelated fix for a pre-existing `clippy::useless_borrows_in_formatting` error in `src/server/snapshots/storage.rs` that CI's newer Rust (1.97) began flagging and which was blocking the clippy gate.

Co-Authored-By: Claude Opus 4.8 
Claude-Session: https://claude.ai/code/session_01GALxr1tEU12E7hHEyfUTa3